### PR TITLE
Configure representation of NGS file

### DIFF
--- a/GenericSimUtilities/src/main/resources/application.conf
+++ b/GenericSimUtilities/src/main/resources/application.conf
@@ -39,8 +39,12 @@ NGSimulator {
        All = "all"
     }
     Graph {
-            fileName = "NetGameSimNetGraph_29-10-23-00-22-06.ngs"
-            outputPath = "./converted"
-            graphLocation = "../../../"
+       fileName = "NetGameSimNetGraph_29-10-23-00-22-06.ngs"
+       outputPath = "./converted"
+       graphLocation = "../../../"
+    }
+    # change contentType to "json" for json representation of generated ngs file
+    OutputGraphRepresentation {
+       contentType = "ngs"
     }
 }

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -26,19 +26,18 @@ trait GraphStore:
     val config = ConfigFactory.load()
     val outputGraphRepresentation = config.getConfig("NGSimulator").getConfig("OutputGraphRepresentation").getString("contentType")
     if (outputGraphRepresentation == "json") then
-      Try {
-        val nodesInGraph: String = sm.nodes().asScala.asJson.noSpaces
-        val edgesInGraph: String = sm.edges().asScala.toList.map { edge =>
-          sm.edgeValue(edge.source(), edge.target()).get
-        }.asJson.noSpaces
+        Try {
+          val nodesInGraph: String = sm.nodes().asScala.asJson.noSpaces
+          val edgesInGraph: String = sm.edges().asScala.toList.map { edge =>
+            sm.edgeValue(edge.source(), edge.target()).get
+          }.asJson.noSpaces
 
-        val file = new FileWriter(s"$dir$fileName")
-        file.write(nodesInGraph + "\n" + edgesInGraph)
-        file.close()
-
-      }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
-        .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
-    else
+          val file = new FileWriter(s"$dir$fileName")
+          file.write(nodesInGraph + "\n" + edgesInGraph)
+          file.close()
+        }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
+          .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
+    else {
       import java.io._
       import java.util.Base64
       import java.nio.charset.StandardCharsets.UTF_8
@@ -52,35 +51,36 @@ trait GraphStore:
           oos.close()
         }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph to $dir$fileName"))
         .recover { case e => NetGraph.logger.error(s"Failed to persist the graph to $dir$fileName : ", e) }
+    }
 
-//  Use the following graphviz command to render the graph to an image:
-//  sfdp -x -Goverlap=scale -Tpng graph.dot > graph.png
-    def toDotVizFormat(name: String, dir: String = outputDirectory, fileName: String, outputImageFormat: Format = Format.DOT): Unit =
-      val nodes: List[NodeObject] = initState :: sm.nodes().asScala.toList
-      if nodes.count(_.id == 0) < 1 then
-        logger.error("The graph does not contain a start node with id 0")
-      else
-        val edges: List[Action] = sm.edges().asScala.toList.map { edge =>
-          sm.edgeValue(edge.source(), edge.target()).get
-        }.sortBy(_.fromNode.id)
-        val nodesMap = nodes.foldLeft(Map[Int, Node]()) { case (acc, nd) =>
-          acc + (nd.id -> (
-            if nd.id == 0 then
-              node(nd.id.toString).`with`(Color.RED).`with`(Label.markdown("**Init**"), Color.rgb("1020d0").font())
-            else
-              node(nd.id.toString)))
-        }
-        val linkedGraph = edges.foldLeft(nodesMap) { case (acc, edge) =>
-          if acc.contains(edge.fromNode.id) && acc.contains(edge.toNode.id) then
-            acc + (edge.fromNode.id -> acc(edge.fromNode.id).link(to(acc(edge.toNode.id)).`with`(weight(if (edge.cost*10).floor < 1 then 1 else (edge.cost*10).floor))))
+  //  Use the following graphviz command to render the graph to an image:
+  //  sfdp -x -Goverlap=scale -Tpng graph.dot > graph.png
+  def toDotVizFormat(name: String, dir: String = outputDirectory, fileName: String, outputImageFormat: Format = Format.DOT): Unit =
+    val nodes: List[NodeObject] = initState :: sm.nodes().asScala.toList
+    if nodes.count(_.id == 0) < 1 then
+      logger.error("The graph does not contain a start node with id 0")
+    else
+      val edges: List[Action] = sm.edges().asScala.toList.map { edge =>
+        sm.edgeValue(edge.source(), edge.target()).get
+      }.sortBy(_.fromNode.id)
+      val nodesMap = nodes.foldLeft(Map[Int, Node]()) { case (acc, nd) =>
+        acc + (nd.id -> (
+          if nd.id == 0 then
+            node(nd.id.toString).`with`(Color.RED).`with`(Label.markdown("**Init**"), Color.rgb("1020d0").font())
           else
-            logger.error(s"Edge $edge is not valid because it contains a node that is not in the graph")
-            acc
-        }
-        val g = graph(name).directed().`with`(linkedGraph.values.toList: _*).
-          linkAttr().`with` ("class", "link-class").`with`(linkedGraph.values.toList: _*)
-        Try(new GraphvizCmdLineEngine()).map(cmdlnEngine => cmdlnEngine.timeout(2, TimeUnit.MINUTES)).map { cmdlnEngine =>
+            node(nd.id.toString)))
+      }
+      val linkedGraph = edges.foldLeft(nodesMap) { case (acc, edge) =>
+        if acc.contains(edge.fromNode.id) && acc.contains(edge.toNode.id) then
+          acc + (edge.fromNode.id -> acc(edge.fromNode.id).link(to(acc(edge.toNode.id)).`with`(weight(if (edge.cost*10).floor < 1 then 1 else (edge.cost*10).floor))))
+        else
+          logger.error(s"Edge $edge is not valid because it contains a node that is not in the graph")
+          acc
+      }
+      val g = graph(name).directed().`with`(linkedGraph.values.toList: _*).
+        linkAttr().`with` ("class", "link-class").`with`(linkedGraph.values.toList: _*)
+      Try(new GraphvizCmdLineEngine()).map(cmdlnEngine => cmdlnEngine.timeout(2, TimeUnit.MINUTES)).map { cmdlnEngine =>
           Graphviz.useEngine(cmdlnEngine)
           Graphviz.fromGraph(g).render(Format.DOT).toFile(new File(s"$dir$fileName.${Format.DOT.fileExtension}"))
         }.map(_ => NetGraph.logger.info(s"Successfully rendered the graph to $dir$fileName.${outputImageFormat.fileExtension}"))
-          .recover { case e => NetGraph.logger.error(s"Failed to render the graph to $dir$fileName.${outputImageFormat.fileExtension} : ", e) }
+        .recover { case e => NetGraph.logger.error(s"Failed to render the graph to $dir$fileName.${outputImageFormat.fileExtension} : ", e) }

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -1,6 +1,7 @@
 package NetGraphAlgebraDefs
 
 import NetGraphAlgebraDefs.NetModelAlgebra.{logger, outputDirectory}
+import com.typesafe.config.ConfigFactory
 import Utilz.NGSConstants
 import guru.nidi.graphviz.attribute.Attributes.attr
 import guru.nidi.graphviz.attribute.LinkAttr.weight
@@ -21,34 +22,36 @@ import io.circe.syntax.*
 
 trait GraphStore:
   self: NetGraph =>
-    def persist(dir: String = outputDirectory, fileName: String = NGSConstants.OUTPUTFILENAME()): Unit =
-      if(fileName.endsWith(NGSConstants.DEFOUTFILEEXT)) then
-        import java.io._
-        import java.util.Base64
-        import java.nio.charset.StandardCharsets.UTF_8
-
-        val fullGraphAsList: List[NetGraphComponent] = sm.nodes().asScala.toList ::: sm.edges().asScala.toList.map { edge =>
+  def persist(dir: String = outputDirectory, fileName: String = NGSConstants.OUTPUTFILENAME()): Unit =
+    val config = ConfigFactory.load()
+    val outputGraphRepresentation = config.getConfig("NGSimulator").getConfig("OutputGraphRepresentation").getString("contentType")
+    if (outputGraphRepresentation == "json") then
+      Try {
+        val nodesInGraph: String = sm.nodes().asScala.asJson.noSpaces
+        val edgesInGraph: String = sm.edges().asScala.toList.map { edge =>
           sm.edgeValue(edge.source(), edge.target()).get
-        }
-        Try(new FileOutputStream(s"$dir$fileName", false)).map(fos => new ObjectOutputStream(fos)).map { oos =>
-            oos.writeObject(fullGraphAsList)
-            oos.flush()
-            oos.close()
-          }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph to $dir$fileName"))
-          .recover { case e => NetGraph.logger.error(s"Failed to persist the graph to $dir$fileName : ", e) }
-      else
-        Try {
-          val nodesInGraph: String = sm.nodes().asScala.asJson.noSpaces
-          val edgesInGraph: String = sm.edges().asScala.toList.map { edge =>
-            sm.edgeValue(edge.source(), edge.target()).get
-          }.asJson.noSpaces
+        }.asJson.noSpaces
 
-          val file = new FileWriter(s"$dir$fileName")
-          file.write(nodesInGraph + "\n" + edgesInGraph)
-          file.close()
+        val file = new FileWriter(s"$dir$fileName")
+        file.write(nodesInGraph + "\n" + edgesInGraph)
+        file.close()
 
-        }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
-          .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
+      }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
+        .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
+    else
+      import java.io._
+      import java.util.Base64
+      import java.nio.charset.StandardCharsets.UTF_8
+
+      val fullGraphAsList: List[NetGraphComponent] = sm.nodes().asScala.toList ::: sm.edges().asScala.toList.map { edge =>
+        sm.edgeValue(edge.source(), edge.target()).get
+      }
+      Try(new FileOutputStream(s"$dir$fileName", false)).map(fos => new ObjectOutputStream(fos)).map { oos =>
+          oos.writeObject(fullGraphAsList)
+          oos.flush()
+          oos.close()
+        }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph to $dir$fileName"))
+        .recover { case e => NetGraph.logger.error(s"Failed to persist the graph to $dir$fileName : ", e) }
 
 //  Use the following graphviz command to render the graph to an image:
 //  sfdp -x -Goverlap=scale -Tpng graph.dot > graph.png


### PR DESCRIPTION
Added the ability to choose between JSON representation or original NGS representation of .ngs file
The previous code generated the .ngs file in encoded format and .ngs.perturbed file in JSON format which would in turn need different deserialization techniques while consuming the original and perturbed graphs

Added a new configuration parameter:
`OutputGraphRepresentation {
       contentType = "ngs"
    }`
   
contentType can be set to "json" to get the original and perturbed ngs files in JSON format
Or can be left to be "ngs" to get the original and perturbed ngs files in the original encoded format