### PR TITLE
[BUGs] Fixes for persisting undirected graphs as .ngs and .dot files

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -54,8 +54,12 @@ trait GraphStore:
       import java.nio.charset.StandardCharsets.UTF_8
 
       val fullGraphAsList: List[NetGraphComponent] = sm.nodes().asScala.toList ::: sm.edges().asScala.toList.map { edge =>
-        sm.edgeValue(edge.source(), edge.target()).get
-      }
+        (if graphDirectionality == "undirected" then
+          sm.edgeValue(edge.nodeU(), edge.nodeV())
+        else
+          sm.edgeValue(edge.source(), edge.target())
+          ).get
+      }.asInstanceOf[List[NetGraphComponent]]
       Try(new FileOutputStream(s"$dir$fileName", false)).map(fos => new ObjectOutputStream(fos)).map { oos =>
           oos.writeObject(fullGraphAsList)
           oos.flush()
@@ -112,18 +116,14 @@ trait GraphStore:
           else
             node(nd.id.toString)))
       }
-      val linkedGraph = edges.foldLeft(nodesMap) { case (acc, edge) =>
-        val fromNodeId = edge.fromNode.id
-        val toNodeId = edge.toNode.id
-        if acc.contains(fromNodeId) && acc.contains(toNodeId) then
-          acc + (fromNodeId -> acc(fromNodeId).link(to(acc(toNodeId)).`with`(weight(if (edge.cost * 10).floor < 1 then 1 else (edge.cost * 10).floor))))
-        else
-        logger.error(s"Edge $edge is not valid because it contains a node that is not in the graph")
-        acc
+      val linkedGraph = edges.map { edge =>
+        nodesMap(edge.fromNode.id).link(to(nodesMap(edge.toNode.id))
+          .`with`(weight(if (edge.cost * 10).floor < 1 then 1 else (edge.cost * 10).floor))
+        )
       }
 
-      val g = graph(name).`with`(linkedGraph.values.toList: _*).
-        linkAttr().`with`("class", "link-class").`with`(linkedGraph.values.toList: _*)
+      val g = graph(name).`with`(nodesMap.values.toList: _*).
+        linkAttr().`with`("class", "link-class").`with`(linkedGraph: _*)
       Try(new GraphvizCmdLineEngine()).map(cmdlnEngine => cmdlnEngine.timeout(2, TimeUnit.MINUTES)).map { cmdlnEngine =>
           Graphviz.useEngine(cmdlnEngine)
           Graphviz.fromGraph(g).render(Format.DOT).toFile(new File(s"$dir$fileName.${Format.DOT.fileExtension}"))


### PR DESCRIPTION
This PR fixes two bugs:

1. `UnsupportedOperationException` when trying to persist an undirected graph as a .ngs file. This was happening because the code did not account for directionality. In the case of undirected nodes, an edge is an unordered pair of nodes `nodeU()` and `nodeV()`, while `source()` and `target()` are used for directed edges. See: [Guava docs](https://guava.dev/releases/snapshot/api/docs/com/google/common/graph/EndpointPair.html)

2. When converting an undirected graph to DOT format, the edges are silently dropped before rendering. This is a semantic bug. As per the [docs](https://github.com/nidi3/graphviz-java?tab=readme-ov-file#api), the graphviz-java API is immutable. Every call to `with()` returns a new object. Although the fold stores the updated source node back in the accumulator, it doesn't update the link's target node's value in the map. Future iterations that produce a newer version of that target node are never updated in an already stored link causing stale references. When the final list is passed, the stale unlinked target instances overwrite the linked ones, causing edges to be silently dropped. This is fixed by building the nodeMap and the edges separately and passing both these values to build the graph. 