### PR TITLE
Fix edge coverage bug, add write failure handling, YAML export, and test coverage

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/ConvertGraph.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/ConvertGraph.scala
@@ -12,38 +12,51 @@ import java.io.*
 import java.net.URL
 import scala.util.{Failure, Success, Try}
 
+// ConvertGraph is a standalone utility that loads original and perturbed .ngs graphs
+// from disk and writes their nodes (as JSON) and edges (as id pairs) to separate
+// plain-text files. These files can be consumed by external analysis tools.
+//
+// The edge output respects graph directionality: for directed graphs, edges are
+// printed as "source -> target"; for undirected graphs, edges use nodeU/nodeV
+// which is order-independent. Without this distinction, directed edge semantics
+// would be lost when converting.
 object ConvertGraph {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     val config = obtainConfigModule(globalConfig, "Graph")
-    val original = config.getString("fileName") //One of the configuration parameters is the name of the file
+    val original = config.getString("fileName")
     val perturbed = s"${original}.perturbed"
-    val dir = config.getString("outputPath") //Where to save the files
-    val sourceDir = config.getString("graphLocation") //Where the graphs are located
+    val dir = config.getString("outputPath")
+    val sourceDir = config.getString("graphLocation")
+    // Read the directionality setting so we use the correct Guava API for edges.
+    // For directed graphs, source()/target() preserves edge direction.
+    // For undirected graphs, nodeU()/nodeV() is the correct accessor.
+    val graphDirectionality = config.getString("directionality")
 
     val originalGraph = NetGraph.load(original, sourceDir)
     val perturbedGraph = NetGraph.load(perturbed, sourceDir)
 
-    val logger = LoggerFactory.getLogger(getClass)
-
-    val originalNodes: PrintWriter = {
-      new PrintWriter(s"${dir}/originalNodes")
-    }
-    val originalEdges: PrintWriter = {
-      new PrintWriter(s"${dir}/originalEdges")
-    }
-    val perturbedNodes: PrintWriter = {
-      new PrintWriter(s"${dir}/perturbedNodes")
-    }
-    val perturbedEdges: PrintWriter = {
-      new PrintWriter(s"${dir}/perturbedEdges")
+    // Helper that writes edges using the correct accessor based on directionality.
+    // Using nodeU()/nodeV() on a directed graph would lose direction information;
+    // using source()/target() on an undirected graph would throw an exception.
+    def writeEdges(graph: NetGraph, writer: PrintWriter): Unit = {
+      graph.sm.edges().forEach(edge => {
+        if graphDirectionality == "undirected" then
+          writer.print(s"${edge.nodeU().id} ${edge.nodeV().id}\n")
+        else
+          writer.print(s"${edge.source().id} ${edge.target().id}\n")
+      })
     }
 
     (originalGraph, perturbedGraph) match {
       case (Some(originalGraph), Some(perturbedGraph)) =>
-
         logger.info("Starting the conversion operation.")
+
+        val originalNodes = new PrintWriter(s"${dir}/originalNodes")
+        val originalEdges = new PrintWriter(s"${dir}/originalEdges")
+        val perturbedNodes = new PrintWriter(s"${dir}/perturbedNodes")
+        val perturbedEdges = new PrintWriter(s"${dir}/perturbedEdges")
 
         originalGraph.sm.nodes().forEach(on => {
           originalNodes.print(s"${on.asJson.noSpaces}\n")
@@ -53,13 +66,9 @@ object ConvertGraph {
           perturbedNodes.print(s"${on.asJson.noSpaces}\n")
         })
 
-        originalGraph.sm.edges().forEach(oe => {
-          originalEdges.print(s"${oe.nodeU().id} ${oe.nodeV().id}\n")
-        })
-
-        perturbedGraph.sm.edges().forEach(pe => {
-          perturbedEdges.print(s"${pe.nodeU().id} ${pe.nodeV().id}\n")
-        })
+        // Use directionality-aware edge writing instead of always using nodeU()/nodeV()
+        writeEdges(originalGraph, originalEdges)
+        writeEdges(perturbedGraph, perturbedEdges)
 
         logger.info("Conversion operation completed")
 
@@ -67,6 +76,11 @@ object ConvertGraph {
         originalEdges.close()
         perturbedNodes.close()
         perturbedEdges.close()
+
+      case _ =>
+        logger.error(s"Failed to load one or both graphs from $sourceDir. " +
+          s"Original='$original' loaded=${originalGraph.isDefined}, " +
+          s"Perturbed='$perturbed' loaded=${perturbedGraph.isDefined}")
     }
   }
 }

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphPerturbationAlgebra.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphPerturbationAlgebra.scala
@@ -243,12 +243,24 @@ object GraphPerturbationAlgebra:
       (acc, elem) => acc ::: List(s"\t\t${elem._2.asInstanceOf[EdgeRemoved].edge.fromNode.id}: ${elem._2.asInstanceOf[EdgeRemoved].edge.toNode.id}\n")
     )
 
+    // Write the modification record to disk. The outer Try handles file-open failures
+    // (e.g. invalid path, permission denied) and the inner Try handles write failures
+    // (e.g. disk full, I/O error mid-write). Both cases return a Left with the error
+    // message so callers can decide how to react.
     Try(new PrintWriter(new File(fileName))) match
       case Success(fh) =>
-        //TODO: add write failure handler
-        try fh.write(allNodesMod.mkString.concat(allEdgesMod.mkString))
-        finally fh.close()
-        Right(())
+        try
+          fh.write(allNodesMod.mkString.concat(allEdgesMod.mkString))
+          if fh.checkError() then
+            fh.close()
+            Left(s"Write to $fileName failed: PrintWriter encountered an I/O error")
+          else
+            fh.close()
+            Right(())
+        catch
+          case ex: Exception =>
+            Try(fh.close())
+            Left(s"Write to $fileName failed: ${ex.getMessage}")
       case Failure(e) => Left(e.getMessage)
 
 

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -23,6 +23,14 @@ import io.circe.syntax.*
 
 trait GraphStore:
   self: NetGraph =>
+
+  // Persists the graph to disk in the format specified by the OutputGraphRepresentation.contentType
+  // configuration parameter. Supported formats:
+  //   - "json"  : Circe JSON with nodes on the first line and edges on the second
+  //   - "yaml"  : Human-readable YAML listing all nodes and edges with their properties
+  //   - "ngs"   : Java binary serialization (default)
+  // The graph directionality (directed/undirected) is read from the Graph.directionality
+  // config and controls which Guava API is used to retrieve edge values.
   def persist(dir: String = outputDirectory, fileName: String = NGSConstants.OUTPUTFILENAME()): Unit =
     val config = ConfigFactory.load()
     val outputGraphRepresentation = config.getConfig("NGSimulator").getConfig("OutputGraphRepresentation").getString("contentType")
@@ -48,6 +56,53 @@ trait GraphStore:
           file.close()
         }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
           .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
+    else if (outputGraphRepresentation == "yaml") then
+        // YAML export: writes a human-readable representation of the graph that is easier
+        // to inspect visually than binary .ngs or dense JSON. The format lists every node
+        // with its properties followed by every edge with its action attributes. This uses
+        // the same directionality-aware edge value retrieval as the JSON and binary formats.
+        Try {
+          val sb = new StringBuilder
+          sb.append("# NetGameSim graph exported in YAML format\n")
+          sb.append(s"directionality: $graphDirectionality\n")
+          sb.append(s"nodeCount: ${sm.nodes().size()}\n")
+          sb.append(s"edgeCount: ${sm.edges().size()}\n")
+          sb.append("nodes:\n")
+          sm.nodes().asScala.toList.sortBy(_.id).foreach { node =>
+            sb.append(s"  - id: ${node.id}\n")
+            sb.append(s"    children: ${node.children}\n")
+            sb.append(s"    props: ${node.props}\n")
+            sb.append(s"    currentDepth: ${node.currentDepth}\n")
+            sb.append(s"    propValueRange: ${node.propValueRange}\n")
+            sb.append(s"    maxDepth: ${node.maxDepth}\n")
+            sb.append(s"    maxBranchingFactor: ${node.maxBranchingFactor}\n")
+            sb.append(s"    maxProperties: ${node.maxProperties}\n")
+            sb.append(s"    storedValue: ${node.storedValue}\n")
+            sb.append(s"    valuableData: ${node.valuableData}\n")
+          }
+          sb.append("edges:\n")
+          sm.edges().asScala.toList.foreach { edge =>
+            val edgeValue = (if (graphDirectionality == "undirected") then
+              sm.edgeValue(edge.nodeU(), edge.nodeV())
+            else
+              sm.edgeValue(edge.source(), edge.target())
+            ).toScala
+            edgeValue match {
+              case Some(action) =>
+                sb.append(s"  - actionType: ${action.actionType}\n")
+                sb.append(s"    fromId: ${action.fromId}\n")
+                sb.append(s"    toId: ${action.toId}\n")
+                sb.append(s"    cost: ${action.cost}\n")
+                sb.append(s"    resultingValue: ${action.resultingValue.getOrElse("null")}\n")
+              case None =>
+                NetGraph.logger.warn("Encountered edge without a value during YAML export, skipping")
+            }
+          }
+          val file = new FileWriter(s"$dir$fileName")
+          file.write(sb.toString)
+          file.close()
+        }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in yaml to $dir$fileName"))
+          .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in yaml to $dir$fileName : ", e) }
     else {
       import java.io._
       import java.util.Base64

--- a/NetModelGenerator/src/main/scala/NetModelAnalyzer/WalkingStats.scala
+++ b/NetModelGenerator/src/main/scala/NetModelAnalyzer/WalkingStats.scala
@@ -36,12 +36,17 @@ class WalkingStats(graph: NetGraph, paths: LISTOFWALKEDPATHS):
     }
   end graphCoverage
 
+  // Computes the percentage of nodes and edges visited by the random walks.
+  // The node coverage is (visited nodes / total nodes) * 100 and
+  // the edge coverage is (visited edges / total edges) * 100.
   def coveragePercentages: (Float, Float) =
     val graphCov = graphCoverage()
     val coveredNodes = graphCov.count((k, v) => v > 0 && k.isInstanceOf[NodeObject])
     val coveredEdges = graphCov.count((k, v) => v > 0 && k.isInstanceOf[Action])
     val nodeCoverage = f"${100f*coveredNodes.toFloat/graphNodes.size}%4.2f".toFloat
-    val edgeCoverage = f"${100f*coveredNodes.toFloat/graphEdges.size}%4.2f".toFloat
+    // Fix: was incorrectly using coveredNodes instead of coveredEdges in the numerator,
+    // which produced wrong edge coverage percentages in all downstream analysis.
+    val edgeCoverage = f"${100f*coveredEdges.toFloat/graphEdges.size}%4.2f".toFloat
     (nodeCoverage, edgeCoverage)
   end coveragePercentages
 

--- a/NetModelGenerator/src/test/scala/NetModelAnalyzer/PathsEstimatorTest.scala
+++ b/NetModelGenerator/src/test/scala/NetModelAnalyzer/PathsEstimatorTest.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2023 Mark Grechanik and Lone Star Consulting, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package NetModelAnalyzer
+
+import NetGraphAlgebraDefs.{Action, NetGraph, NetGraphComponent, NetModelAlgebra, NodeObject}
+import Utilz.CreateLogger
+import com.google.common.graph.{MutableValueGraph, ValueGraphBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.Logger
+
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Tests for PathsEstimator, which determines unexplored paths in the graph
+ * after a set of random walks and divides them among multiple MapApps using
+ * a fair cake-cutting strategy.
+ *
+ * The test graph used here is a simple 5-node directed graph:
+ *
+ *   1 -> 2 -> 3
+ *   |         ^
+ *   v         |
+ *   4 ------> 5
+ *
+ * This structure ensures that some nodes and edges may remain unvisited
+ * after short random walks, giving PathsEstimator something to recommend.
+ */
+class PathsEstimatorTest extends AnyFlatSpec with Matchers {
+  val logger: Logger = CreateLogger(this.getClass)
+
+  // Reusable test nodes
+  val node1: NodeObject = NodeObject(id = 1, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node2: NodeObject = NodeObject(id = 2, children = 2, props = 2, propValueRange = 2, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node3: NodeObject = NodeObject(id = 3, children = 3, props = 3, propValueRange = 3, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node4: NodeObject = NodeObject(id = 4, children = 4, props = 4, propValueRange = 4, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node5: NodeObject = NodeObject(id = 5, children = 5, props = 5, propValueRange = 5, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+
+  val edge12: Action = Action(actionType = 1, fromNode = node1, toNode = node2, fromId = 1, toId = 2, resultingValue = Some(1), cost = 0.1)
+  val edge23: Action = Action(actionType = 2, fromNode = node2, toNode = node3, fromId = 2, toId = 3, resultingValue = Some(2), cost = 0.2)
+  val edge14: Action = Action(actionType = 3, fromNode = node1, toNode = node4, fromId = 1, toId = 4, resultingValue = Some(3), cost = 0.3)
+  val edge45: Action = Action(actionType = 4, fromNode = node4, toNode = node5, fromId = 4, toId = 5, resultingValue = Some(4), cost = 0.4)
+  val edge53: Action = Action(actionType = 5, fromNode = node5, toNode = node3, fromId = 5, toId = 3, resultingValue = Some(5), cost = 0.5)
+
+  def createTestGraph(): NetGraph = {
+    val graph: MutableValueGraph[NodeObject, Action] = ValueGraphBuilder.directed().build()
+    graph.addNode(node1)
+    graph.addNode(node2)
+    graph.addNode(node3)
+    graph.addNode(node4)
+    graph.addNode(node5)
+    graph.putEdgeValue(node1, node2, edge12)
+    graph.putEdgeValue(node2, node3, edge23)
+    graph.putEdgeValue(node1, node4, edge14)
+    graph.putEdgeValue(node4, node5, edge45)
+    graph.putEdgeValue(node5, node3, edge53)
+    NetGraph(graph, node1)
+  }
+
+  behavior of "PathsEstimator"
+
+  // Verify that the exploration map is initialized with all graph nodes and edges,
+  // each starting with a visit count of zero.
+  it should "initialize the exploration map with all nodes and edges at zero" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    val nodeCount = graph.sm.nodes().size()
+    val edgeCount = graph.sm.edges().size()
+    pe.explorationMap.size shouldBe nodeCount + edgeCount
+    pe.explorationMap.values.forall(_ == 0) shouldBe true
+    logger.info(s"Exploration map initialized with ${pe.explorationMap.size} entries (${nodeCount} nodes + ${edgeCount} edges)")
+  }
+
+  // When paths are empty (no walks performed), every node and edge is unexplored
+  // so exploreThesePaths should return all graph components as recommendations.
+  it should "return all components as unexplored when given empty paths" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    val emptyPaths: LISTOFWALKEDPATHS = List.empty
+    val result = pe.exploreThesePaths(emptyPaths, 3)
+    val allUnexplored = result.flatten
+    val nodeCount = graph.sm.nodes().size()
+    val edgeCount = graph.sm.edges().size()
+    // All nodes and edges should be unexplored since no walks were given
+    allUnexplored.size shouldBe nodeCount + edgeCount
+    logger.info(s"With empty paths, all ${allUnexplored.size} components are unexplored")
+  }
+
+  // After walking some paths, the components visited should no longer appear
+  // in the unexplored recommendations from exploreThesePaths.
+  it should "exclude already-visited components from recommendations" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    // Simulate a walk that covers the path 1->2->3 (node1, edge12, node2, edge23, node3)
+    val simulatedWalk: PATHRESULT = List(
+      (node2, edge12),
+      (node3, edge23)
+    )
+    val result = pe.exploreThesePaths(List(simulatedWalk), 2)
+    val unexplored = result.flatten
+    // node2, node3, edge12, and edge23 were visited — they should NOT be in the result
+    unexplored should not contain node2
+    unexplored should not contain node3
+    unexplored should not contain edge12
+    unexplored should not contain edge23
+    // node1, node4, node5, edge14, edge45, edge53 were not visited — they should be present
+    unexplored should contain(node4)
+    unexplored should contain(node5)
+    logger.info(s"After walking 1->2->3, ${unexplored.size} components remain unexplored")
+  }
+
+  // The malapps parameter controls how the unexplored components are divided
+  // into groups. With 2 malapps we should get at most 2 groups.
+  it should "divide unexplored components among the specified number of malapps" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    val emptyPaths: LISTOFWALKEDPATHS = List.empty
+    val malapps = 2
+    val result = pe.exploreThesePaths(emptyPaths, malapps)
+    // Each group should have at most ceil(total / malapps) components
+    // and there should be ceil(total / malapps) groups
+    result.foreach(group => group.size should be <= (graph.sm.nodes().size() + graph.sm.edges().size()))
+    logger.info(s"Unexplored components divided into ${result.size} groups for $malapps malapps")
+  }
+
+  // When all paths have been walked (all nodes and edges visited),
+  // exploreThesePaths should return an empty recommendation list.
+  it should "return empty recommendations when all components have been visited" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    // Simulate walks that cover every node and edge in the graph
+    val walk1: PATHRESULT = List(
+      (node2, edge12),
+      (node3, edge23)
+    )
+    val walk2: PATHRESULT = List(
+      (node4, edge14),
+      (node5, edge45),
+      (node3, edge53)
+    )
+    // Also need to mark node1 as visited — it appears as the _1 component
+    val walk3: PATHRESULT = List(
+      (node1, edge12)
+    )
+    val result = pe.exploreThesePaths(List(walk1, walk2, walk3), 3)
+    val unexplored = result.flatten
+    unexplored shouldBe empty
+    logger.info("All components visited — no recommendations returned")
+  }
+
+  // Verify that repeated calls to exploreThesePaths accumulate visit counts
+  // in the exploration map (the map is mutable and persists across calls).
+  it should "accumulate visit counts across multiple calls" in {
+    val graph = createTestGraph()
+    val pe = PathsEstimator(graph)
+    val walk1: PATHRESULT = List((node2, edge12))
+    pe.exploreThesePaths(List(walk1), 2)
+    // After first call, node2 and edge12 should each have count 1
+    pe.explorationMap(node2) shouldBe 1
+    pe.explorationMap(edge12) shouldBe 1
+    // Call again with the same walk
+    pe.exploreThesePaths(List(walk1), 2)
+    // Counts should accumulate to 2
+    pe.explorationMap(node2) shouldBe 2
+    pe.explorationMap(edge12) shouldBe 2
+    logger.info(s"Visit counts accumulated correctly: node2=${pe.explorationMap(node2)}, edge12=${pe.explorationMap(edge12)}")
+  }
+}

--- a/NetModelGenerator/src/test/scala/NetModelAnalyzer/WalkingStatsTest.scala
+++ b/NetModelGenerator/src/test/scala/NetModelAnalyzer/WalkingStatsTest.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2023 Mark Grechanik and Lone Star Consulting, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package NetModelAnalyzer
+
+import NetGraphAlgebraDefs.{Action, NetGraph, NetGraphComponent, NetModelAlgebra, NodeObject}
+import Utilz.CreateLogger
+import com.google.common.graph.{MutableValueGraph, ValueGraphBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.Logger
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Tests for WalkingStats, which computes graph coverage statistics
+ * based on random walk results. Coverage is measured by how many
+ * distinct nodes and edges were visited across all walks.
+ *
+ * These tests verify:
+ *  - graphCoverage() correctly counts visits per node/edge
+ *  - coveragePercentages computes node and edge coverage independently
+ *  - Edge coverage uses the correct numerator (coveredEdges, not coveredNodes)
+ *  - Empty walks produce zero coverage
+ *  - Full walks produce 100% coverage
+ *
+ * The test graph is a 4-node directed chain:
+ *   1 -> 2 -> 3 -> 4
+ */
+class WalkingStatsTest extends AnyFlatSpec with Matchers {
+  val logger: Logger = CreateLogger(this.getClass)
+
+  val node1: NodeObject = NodeObject(id = 1, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node2: NodeObject = NodeObject(id = 2, children = 2, props = 2, propValueRange = 2, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node3: NodeObject = NodeObject(id = 3, children = 3, props = 3, propValueRange = 3, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node4: NodeObject = NodeObject(id = 4, children = 4, props = 4, propValueRange = 4, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+
+  val edge12: Action = Action(actionType = 1, fromNode = node1, toNode = node2, fromId = 1, toId = 2, resultingValue = Some(1), cost = 0.1)
+  val edge23: Action = Action(actionType = 2, fromNode = node2, toNode = node3, fromId = 2, toId = 3, resultingValue = Some(2), cost = 0.2)
+  val edge34: Action = Action(actionType = 3, fromNode = node3, toNode = node4, fromId = 3, toId = 4, resultingValue = Some(3), cost = 0.3)
+
+  def createChainGraph(): NetGraph = {
+    val graph: MutableValueGraph[NodeObject, Action] = ValueGraphBuilder.directed().build()
+    graph.addNode(node1)
+    graph.addNode(node2)
+    graph.addNode(node3)
+    graph.addNode(node4)
+    graph.putEdgeValue(node1, node2, edge12)
+    graph.putEdgeValue(node2, node3, edge23)
+    graph.putEdgeValue(node3, node4, edge34)
+    NetGraph(graph, node1)
+  }
+
+  behavior of "WalkingStats"
+
+  // When no walks are provided, every node and edge should have a visit count
+  // of zero, meaning nothing was covered.
+  it should "report zero coverage when no walks are provided" in {
+    val graph = createChainGraph()
+    val stats = new WalkingStats(graph, List.empty)
+    val coverage = stats.graphCoverage()
+    // All entries should be zero since no walks happened
+    coverage.values.forall(_ == 0) shouldBe true
+    val (nodeCov, edgeCov) = stats.coveragePercentages
+    nodeCov shouldBe 0.0f
+    edgeCov shouldBe 0.0f
+    logger.info(s"Zero walks: node coverage=$nodeCov%, edge coverage=$edgeCov%")
+  }
+
+  // A walk that visits only part of the graph should produce partial coverage.
+  // Walking 1->2 covers 2 of 4 nodes and 1 of 3 edges.
+  it should "compute partial coverage for a walk that visits a subset of the graph" in {
+    val graph = createChainGraph()
+    // Walk visits node2 via edge12 — covers node2 and edge12
+    val walk: PATHRESULT = List((node2, edge12))
+    val stats = new WalkingStats(graph, List(walk))
+    val coverage = stats.graphCoverage()
+    // node2 and edge12 should have count 1
+    coverage(node2) shouldBe 1
+    coverage(edge12) shouldBe 1
+    // node1, node3, node4, edge23, edge34 should have count 0
+    coverage(node1) shouldBe 0
+    coverage(node3) shouldBe 0
+    coverage(node4) shouldBe 0
+    coverage(edge23) shouldBe 0
+    coverage(edge34) shouldBe 0
+    logger.info(s"Partial walk coverage map: $coverage")
+  }
+
+  // Regression test for the bug where edge coverage was computed using
+  // coveredNodes instead of coveredEdges. To catch this, we need a walk
+  // where coveredNodes != coveredEdges. Visiting the same node (node2)
+  // via two different edges (edge12, edge23) gives 1 unique covered node
+  // but 2 unique covered edges. With the bug, both percentages would use
+  // coveredNodes=1 as numerator; with the fix, edge coverage correctly
+  // uses coveredEdges=2.
+  it should "compute node and edge coverage percentages independently" in {
+    val graph = createChainGraph()
+    // Walk visits node2 twice (via edge12 and edge23), so coveredNodes=1
+    // but coveredEdges=2 — these must produce different percentages.
+    val walk: PATHRESULT = List(
+      (node2, edge12),
+      (node2, edge23)
+    )
+    val stats = new WalkingStats(graph, List(walk))
+    val (nodeCov, edgeCov) = stats.coveragePercentages
+    // 1 of 4 nodes covered = 25%
+    nodeCov shouldBe 25.0f
+    // 2 of 3 edges covered = 66.67%
+    // With the old bug, this would wrongly be 100*1/3 = 33.33%
+    edgeCov shouldBe 66.67f +- 0.01f
+    // Sanity check: node and edge coverage MUST differ for this test to
+    // catch the bug where edge coverage accidentally used coveredNodes.
+    nodeCov should not be edgeCov
+    logger.info(s"Independent coverage: nodes=$nodeCov%, edges=$edgeCov%")
+  }
+
+  // When a walk covers every node and edge, both coverages should be 100%.
+  it should "report 100% coverage when all nodes and edges are visited" in {
+    val graph = createChainGraph()
+    val walk: PATHRESULT = List(
+      (node2, edge12),
+      (node3, edge23),
+      (node4, edge34)
+    )
+    // node1 is not visited by the walk steps above — we need a second walk
+    // that includes node1. In the walk format, the first element of each
+    // tuple is the destination node. So we add node1 as a visited component.
+    val walk2: PATHRESULT = List(
+      (node1, edge12)
+    )
+    val stats = new WalkingStats(graph, List(walk, walk2))
+    val (nodeCov, edgeCov) = stats.coveragePercentages
+    nodeCov shouldBe 100.0f
+    edgeCov shouldBe 100.0f
+    logger.info(s"Full coverage: nodes=$nodeCov%, edges=$edgeCov%")
+  }
+
+  // Multiple walks should accumulate visit counts. If node2 is visited
+  // in two separate walks, its count should be 2.
+  it should "accumulate visit counts from multiple walks" in {
+    val graph = createChainGraph()
+    val walk1: PATHRESULT = List((node2, edge12))
+    val walk2: PATHRESULT = List((node2, edge12), (node3, edge23))
+    val stats = new WalkingStats(graph, List(walk1, walk2))
+    val coverage = stats.graphCoverage()
+    // node2 appears in both walks, so its count should be 2
+    coverage(node2) shouldBe 2
+    // edge12 also appears in both walks
+    coverage(edge12) shouldBe 2
+    // node3 and edge23 appear only in walk2
+    coverage(node3) shouldBe 1
+    coverage(edge23) shouldBe 1
+    logger.info(s"Accumulated coverage: node2=${coverage(node2)}, edge12=${coverage(edge12)}")
+  }
+
+  // The graphCoverage map should contain an entry for every node and edge
+  // in the graph, even those not visited.
+  it should "include all graph components in the coverage map" in {
+    val graph = createChainGraph()
+    val stats = new WalkingStats(graph, List.empty)
+    val coverage = stats.graphCoverage()
+    val nodeCount = graph.sm.nodes().size()
+    val edgeCount = graph.sm.edges().size()
+    // The map should have entries for all 4 nodes and all 3 edges
+    coverage.size shouldBe nodeCount + edgeCount
+    coverage.keys.count(_.isInstanceOf[NodeObject]) shouldBe nodeCount
+    coverage.keys.count(_.isInstanceOf[Action]) shouldBe edgeCount
+    logger.info(s"Coverage map has ${coverage.size} entries ($nodeCount nodes + $edgeCount edges)")
+  }
+}


### PR DESCRIPTION
## At a Glance

| # | Type | File | What changed |
|---|------|------|--------------|
| 1 | **Bug fix** | `WalkingStats.scala:44` | Edge coverage percentage used wrong variable — `coveredNodes` instead of `coveredEdges` |
| 2 | **Bug fix** | `ConvertGraph.scala:57-59` | Directed graph edges lost direction — always used `nodeU()/nodeV()` instead of `source()/target()` |
| 3 | **TODO fix** | `GraphPerturbationAlgebra.scala:248` | Implemented the `//TODO: add write failure handler` requested in code |
| 4 | **Feature** | `GraphStore.scala:59-105` | Added `"yaml"` as a third `contentType` option for graph export |
| 5 | **Tests** | `PathsEstimatorTest.scala` | 6 new tests — this module had **zero** tests before |
| 6 | **Tests** | `WalkingStatsTest.scala` | 6 new tests including a regression test that catches bug #1 |

---

## 1. Bug Fix — Wrong edge coverage percentage (`WalkingStats.scala`)

**The problem:** In `coveragePercentages`, line 44 computes edge coverage but accidentally uses `coveredNodes` in the numerator instead of `coveredEdges`. This means every edge coverage metric reported anywhere in the project (including `Analyzer.computeWalksStats` which logs coverage) is **wrong**.

**Before (line 44):**
```scala
val edgeCoverage = f"${100f*coveredNodes.toFloat/graphEdges.size}%4.2f".toFloat
//                          ^^^^^^^^^^^^ BUG: should be coveredEdges
```

**After:**
```scala
val edgeCoverage = f"${100f*coveredEdges.toFloat/graphEdges.size}%4.2f".toFloat
```

**Concrete example of the impact:** If a random walk visits 1 unique node but traverses 2 unique edges on a graph with 4 nodes and 3 edges:
- **Old (wrong):** edge coverage = 100 × 1 / 3 = **33.33%**
- **New (correct):** edge coverage = 100 × 2 / 3 = **66.67%**

The new `WalkingStatsTest` includes a regression test that specifically constructs this scenario (same node visited via two different edges) to ensure node and edge coverage are always computed independently.

---

## 2. Bug Fix — Directed edges losing direction in `ConvertGraph.scala`

**The problem:** When exporting edges, the old code unconditionally called `nodeU()/nodeV()` on all edges (lines 57–59). For **undirected** graphs this is correct. But for **directed** graphs, `nodeU()/nodeV()` does not guarantee source→target ordering — the Guava docs say the order is arbitrary. The correct API for directed graphs is `source()/target()`.

This is the same class of bug that was already fixed in `GraphStore.scala` and `toDotVizFormat()` (see PR #8 — undirected serialization bugs), but `ConvertGraph` was missed.

**Before:**
```scala
originalGraph.sm.edges().forEach(oe => {
  originalEdges.print(s"${oe.nodeU().id} ${oe.nodeV().id}\n")  // always nodeU/nodeV
})
```

**After:**
```scala
def writeEdges(graph: NetGraph, writer: PrintWriter): Unit = {
  graph.sm.edges().forEach(edge => {
    if graphDirectionality == "undirected" then
      writer.print(s"${edge.nodeU().id} ${edge.nodeV().id}\n")
    else
      writer.print(s"${edge.source().id} ${edge.target().id}\n")
  })
}
```

Also added an error-handling `case _` for when graph loading fails — the original match was non-exhaustive and would silently do nothing if one graph file was missing.

---

## 3. TODO Fix — Write failure handler in `GraphPerturbationAlgebra.persist`

**The problem:** There is an explicit TODO comment at line 248 asking for a write failure handler:

```scala
Try(new PrintWriter(new File(fileName))) match
  case Success(fh) =>
    //TODO: add write failure handler      <-- THIS LINE
    try fh.write(...)
    finally fh.close()
```

The outer `Try` only catches file-open failures (bad path, permission denied). But if the `fh.write()` itself fails (disk full, I/O error mid-write), `PrintWriter` **silently swallows** the exception — it does not throw. The only way to detect it is via `PrintWriter.checkError()`.

**After:**
```scala
case Success(fh) =>
  try
    fh.write(allNodesMod.mkString.concat(allEdgesMod.mkString))
    if fh.checkError() then
      fh.close()
      Left(s"Write to $fileName failed: PrintWriter encountered an I/O error")
    else
      fh.close()
      Right(())
  catch
    case ex: Exception =>
      Try(fh.close())
      Left(s"Write to $fileName failed: ${ex.getMessage}")
```

---

## 4. Feature — YAML graph export (`GraphStore.scala`)

`GraphStore.persist()` previously supported two formats via the `OutputGraphRepresentation.contentType` config:
- `"ngs"` — Java binary serialization (default)
- `"json"` — Circe JSON (added in PR #4)

This PR adds `"yaml"` as a third option. The YAML format lists all nodes and edges with their properties in a human-readable structure:

```yaml
# NetGameSim graph exported in YAML format
directionality: directed
nodeCount: 500
edgeCount: 1247
nodes:
  - id: 0
    children: 3
    props: 7
    ...
edges:
  - actionType: 5
    fromId: 0
    toId: 12
    cost: 0.42
    ...
```

This is useful for quick visual inspection of graph structure without needing a JSON viewer or deserializer. No new dependencies required — the YAML is formatted using `StringBuilder`. Uses the same directionality-aware edge value retrieval as JSON and binary formats.

To use: set `contentType = "yaml"` in the `OutputGraphRepresentation` section of `application.conf`.

---

## 5–6. New Tests — `PathsEstimatorTest` and `WalkingStatsTest`

Both `PathsEstimator` and `WalkingStats` had **no dedicated test files**. `WalkingStats` was only tested indirectly via `RandomWalkerTest` (which itself was using the buggy `coveragePercentages`).

**PathsEstimatorTest (6 tests):**
1. Exploration map initializes with all nodes + edges at count 0
2. Empty paths → all components returned as unexplored
3. Visited components are excluded from recommendations
4. Unexplored components are divided into groups by `malapps` parameter
5. When everything is visited → empty recommendation list
6. Visit counts accumulate across multiple calls (mutable map behavior)

**WalkingStatsTest (6 tests):**
1. Zero coverage when no walks provided
2. Partial coverage counts individual node/edge visits
3. **Regression test for bug #1:** constructs a walk where `coveredNodes ≠ coveredEdges` (same node via 2 different edges) and asserts `nodeCov ≠ edgeCov`
4. 100% coverage when all nodes and edges visited
5. Multi-walk accumulation of visit counts
6. Coverage map contains entries for every graph component

All tests follow the existing project conventions: `AnyFlatSpec` with `Matchers`, manual graph construction via `ValueGraphBuilder`, Apache 2.0 license header.