### PR TITLE
Fix NodeObject.modify passing wrong randomization bound for maxBranchingFactor

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraphComponent.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraphComponent.scala
@@ -28,6 +28,14 @@ case class NodeObject(id: Int, children: Int, props: Int, currentDepth: Int = 1,
       ))
     else List.empty
   def childrenCount: Int = children + childrenObjects.map(_.childrenCount).sum
+  // Produces a modified version of this node for perturbation. The positional
+  // arguments must match the NodeObject constructor order:
+  //   id, children, props, currentDepth, propValueRange, maxDepth,
+  //   maxBranchingFactor, maxProperties, storedValue, valuableData.
+  // Position 7 is maxBranchingFactor — it must be randomized against this
+  // node's own maxBranchingFactor, NOT propValueRange. Previously the code
+  // passed propValueRange here by mistake, which silently skewed every
+  // perturbed node's branching factor toward an unrelated range.
   def modify: NodeObject =
     NodeObject(id,
       children,
@@ -35,7 +43,7 @@ case class NodeObject(id: Int, children: Int, props: Int, currentDepth: Int = 1,
       currentDepth,
       SupplierOfRandomness.onDemandInt(pmaxv = propValueRange, repeatable = false),
       maxDepth,
-      SupplierOfRandomness.onDemandInt(pmaxv = propValueRange, repeatable = false),
+      SupplierOfRandomness.onDemandInt(pmaxv = maxBranchingFactor, repeatable = false),
       maxProperties,
       SupplierOfRandomness.onDemandReal(repeatable = false),
       valuableData

--- a/NetModelGenerator/src/test/scala/NetGraphAlgebraDefs/NetObjectTest.scala
+++ b/NetModelGenerator/src/test/scala/NetGraphAlgebraDefs/NetObjectTest.scala
@@ -19,4 +19,46 @@ class NetObjectTest extends AnyFlatSpec with Matchers with MockitoSugar {
     when(mockRandomizer.onDemandInt()).thenReturn(1)
     mockRandomizer.onDemandInt() shouldBe 1
   }
+
+  behavior of "NodeObject.modify"
+
+  // Regression test: NodeObject.modify previously used propValueRange as the
+  // randomization bound for maxBranchingFactor (position 7 in the constructor).
+  // That silently skewed every perturbed node's branching factor. This test
+  // exercises modify() many times and confirms maxBranchingFactor stays within
+  // the original node's maxBranchingFactor bound, not propValueRange.
+  it should "respect each field's own bound when generating a modified node" in {
+    // Use a deliberately skewed configuration so the old bug would be visible:
+    // if maxBranchingFactor is 3 but propValueRange is 99, the old code could
+    // produce maxBranchingFactor values up to 99 — the fix keeps it in [0, 3].
+    val node = NodeObject(
+      id = 1,
+      children = 2,
+      props = 4,
+      currentDepth = 1,
+      propValueRange = 99,
+      maxDepth = 5,
+      maxBranchingFactor = 3,
+      maxProperties = 10,
+      storedValue = 1.0,
+      valuableData = false
+    )
+    val trials = 200
+    val results = (1 to trials).map(_ => node.modify)
+    // The modified maxBranchingFactor must never exceed the original node's
+    // maxBranchingFactor. If the old bug regressed, we would see values above 3.
+    val violating = results.filter(_.maxBranchingFactor > node.maxBranchingFactor)
+    violating shouldBe empty
+    // Fields we never randomize in modify() must be preserved byte-for-byte.
+    results.foreach { m =>
+      m.id shouldBe node.id
+      m.children shouldBe node.children
+      m.props shouldBe node.props
+      m.currentDepth shouldBe node.currentDepth
+      m.maxDepth shouldBe node.maxDepth
+      m.maxProperties shouldBe node.maxProperties
+      m.valuableData shouldBe node.valuableData
+    }
+    logger.info(s"modify() produced $trials nodes, max observed maxBranchingFactor=${results.map(_.maxBranchingFactor).max} (bound: ${node.maxBranchingFactor})")
+  }
 }


### PR DESCRIPTION
## What this fixes

`NodeObject.modify` in [`NetGraphComponent.scala`](NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraphComponent.scala) passes the wrong randomization bound for the **7th constructor argument**.

The `NodeObject` constructor signature is:
```scala
case class NodeObject(
  id: Int,                 // pos 1
  children: Int,           // pos 2
  props: Int,              // pos 3
  currentDepth: Int,       // pos 4
  propValueRange: Int,     // pos 5
  maxDepth: Int,           // pos 6
  maxBranchingFactor: Int, // pos 7  <-- this position
  maxProperties: Int,      // pos 8
  storedValue: Double,     // pos 9
  valuableData: Boolean    // pos 10
)
```

### Before

```scala
def modify: NodeObject =
  NodeObject(id, children, props, currentDepth,
    SupplierOfRandomness.onDemandInt(pmaxv = propValueRange, ...),  // pos 5: propValueRange ✓
    maxDepth,                                                        // pos 6
    SupplierOfRandomness.onDemandInt(pmaxv = propValueRange, ...),  // pos 7: BUG - should use maxBranchingFactor
    maxProperties, ..., valuableData)
```

### After

```scala
  SupplierOfRandomness.onDemandInt(pmaxv = maxBranchingFactor, ...),  // pos 7: correct bound
```

## Why this matters

Every perturbed node silently got a `maxBranchingFactor` randomized against an **unrelated** range (`propValueRange`). If a graph was generated with `propValueRange = 100` and `maxBranchingFactor = 7` (the defaults in `application.conf`), every perturbed node's `maxBranchingFactor` could be up to 100 instead of 7 — skewing perturbation semantics across all experiments.

## Regression test

Added a test in `NetObjectTest.scala` that:

1. Constructs a node with a deliberately skewed configuration: `propValueRange = 99`, `maxBranchingFactor = 3`
2. Calls `modify()` 200 times
3. Asserts that **no** resulting node has `maxBranchingFactor > 3`

Under the old buggy code, this would fail on most trials (values up to 99 would appear).

## Test Plan

- [ ] Run `sbt test` and confirm `NetObjectTest` passes with the new regression test
- [ ] Reviewers can verify the fix by temporarily reverting the one-line change and re-running the test — it should fail