### PR TITLE
Remove redundant duplicate DFS traversal in unreachableNodes

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
@@ -208,10 +208,14 @@ case class NetGraph(sm: NetStateMachine, initState: NodeObject)
       }
 
       val (reachableNodes: Set[NodeObject], loops: Int) = {
+        // The directed branch previously ran dfs twice: once assigned to a
+        // local `val rns` and once as the block's trailing expression. Because
+        // a Scala block returns its last expression, the first call's result
+        // was silently discarded, doubling the reachability work on every
+        // call. We now run dfs exactly once and use its result.
         val rns = if (graphDirectionality == "undirected") {
           dfsUndirected(sm.successors(initState).asScala.toList, Set())
         } else {
-          val rns = dfs(sm.successors(initState).asScala.toList, Set())
           dfs(sm.successors(initState).asScala.toList, Set())
         }
         logger.info(s"DFS: reachable ${rns.size} nodes with $loopsInGraph loops in the graph")


### PR DESCRIPTION
## What this fixes

In [`NetGraph.unreachableNodes()`](NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala) the directed branch of the reachability computation was calling `dfs()` **twice**, with the first call's result silently discarded by Scala's block semantics.

### Before

```scala
val (reachableNodes: Set[NodeObject], loops: Int) = {
  val rns = if (graphDirectionality == \"undirected\") {
    dfsUndirected(sm.successors(initState).asScala.toList, Set())
  } else {
    val rns = dfs(sm.successors(initState).asScala.toList, Set())   // result discarded
    dfs(sm.successors(initState).asScala.toList, Set())              // this one is returned
  }
  ...
}
```

A Scala block returns its last expression. So the shadowed inner `val rns` was dead — assigned and never read — and two full DFS traversals ran on every directed-graph reachability check.

### After

```scala
val rns = if (graphDirectionality == \"undirected\") {
  dfsUndirected(sm.successors(initState).asScala.toList, Set())
} else {
  dfs(sm.successors(initState).asScala.toList, Set())
}
```

## Why this matters

`unreachableNodes()` is invoked during graph generation via `forceReachability`, on every configured experiment run. On a 500-node graph (the default `statesTotal` in `application.conf`), each reachability check performs a full DFS over the successor set. Running it twice per call wastes 100% of one of the two traversals — a straightforward 2× CPU regression.

## Test Plan

- [ ] Run `sbt test` to confirm nothing regresses (existing `NetGraphTest` exercises reachability indirectly through graph generation)
- [ ] Manually verify by running `Main` — the log line `DFS: reachable N nodes` should appear once per call instead of implicitly twice