### PR TITLE
Guard CostRewardCalculator against NaN from empty walk paths

### DIFF
--- a/NetModelGenerator/src/main/scala/NetModelAnalyzer/CostRewardCalculator.scala
+++ b/NetModelGenerator/src/main/scala/NetModelAnalyzer/CostRewardCalculator.scala
@@ -62,7 +62,17 @@ object CostRewardCalculator extends CostRewardFunction:
     (costs:COSTTUPLE) => {
       import NetGraphAlgebraDefs.NetModelAlgebra.*
       val pathLength = v1.size.toDouble
-      val avgWeight: Double = v1.map(_._2.asInstanceOf[Action].cost).sum / pathLength
+      // Guard against an empty PATHRESULT. RandomWalker.trimPath can produce
+      // an empty list when a random walk terminates immediately at a
+      // TerminalNode — the only element gets dropped, leaving an empty path.
+      // Without this guard the expression below evaluated to `sum / 0.0`,
+      // yielding NaN. That NaN then flowed into MalAppBudget.reward/penalty
+      // and silently poisoned every subsequent budget/score calculation
+      // for the whole run. When the path is empty there is nothing to
+      // reward or penalize, so avgWeight is simply 0.
+      val avgWeight: Double =
+        if pathLength > 0d then v1.map(_._2.asInstanceOf[Action].cost).sum / pathLength
+        else 0d
 
       val (newCost:COSTTUPLE, dc:DetectedModifiedComponents) = computeCosts4Walk(v1, costs, v3)
       if math.abs(newCost._2.toDouble - costs._2.toDouble) > NGSConstants.EPSILON then

--- a/NetModelGenerator/src/test/scala/NetModelAnalyzer/CostRewardCalculatorTest.scala
+++ b/NetModelGenerator/src/test/scala/NetModelAnalyzer/CostRewardCalculatorTest.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Mark Grechanik and Lone Star Consulting, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package NetModelAnalyzer
+
+import NetGraphAlgebraDefs.{Action, NodeObject}
+import NetModelAnalyzer.Budget.{MalAppBudget, TargetAppScore}
+import Utilz.CreateLogger
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.Logger
+
+/**
+ * Tests for CostRewardCalculator focused on defensive behavior around empty
+ * walk paths. The module previously contained no dedicated test file — it
+ * was only exercised indirectly through GraphPerturbationAlgebraTest.
+ *
+ * The principal test here is the regression for the empty-path
+ * division-by-zero bug: when RandomWalker.trimPath produces an empty
+ * PATHRESULT (a walk that terminated immediately at a TerminalNode),
+ * avgWeight was computed as `sum / 0.0`, yielding NaN that then
+ * propagated through every subsequent budget/score update.
+ */
+class CostRewardCalculatorTest extends AnyFlatSpec with Matchers {
+  val logger: Logger = CreateLogger(this.getClass)
+
+  val nodeA: NodeObject = NodeObject(id = 1, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val nodeB: NodeObject = NodeObject(id = 2, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val edgeAB: Action = Action(actionType = 1, fromNode = nodeA, toNode = nodeB, fromId = 1, toId = 2, resultingValue = Some(1), cost = 0.5)
+
+  behavior of "CostRewardCalculator"
+
+  // Regression test for the empty-path division-by-zero bug. Before the fix,
+  // the calculator computed avgWeight as `sum / pathLength` where pathLength
+  // was 0.0 for an empty path, yielding NaN. That NaN was then fed into
+  // MalAppBudget.reward(avgWeight) or MalAppBudget.penalty(avgWeight),
+  // poisoning every downstream budget update for the remainder of the run.
+  // After the fix, an empty path produces avgWeight = 0.0 and the returned
+  // costs are finite numbers that can safely feed later calculations.
+  it should "not produce NaN when the walk path is empty" in {
+    val emptyPath: PATHRESULT = List.empty
+    val modRecord = Map.empty[NetGraphAlgebraDefs.NetGraphComponent, Double]
+    val initialCosts = (MalAppBudget(10.0), TargetAppScore(5.0))
+
+    val ((newBudget, newScore), detected) =
+      CostRewardCalculator(emptyPath, modRecord, List())(initialCosts)
+
+    newBudget.toDouble.isNaN shouldBe false
+    newBudget.toDouble.isInfinite shouldBe false
+    newScore.toDouble.isNaN shouldBe false
+    newScore.toDouble.isInfinite shouldBe false
+    // An empty walk detects no modifications, so the detected list is empty.
+    detected shouldBe empty
+    logger.info(s"Empty path safely handled: budget=${newBudget.toDouble}, score=${newScore.toDouble}")
+  }
+
+  // Sanity check: a non-empty path should still compute finite values after
+  // the fix. The guard only short-circuits when pathLength is zero, so
+  // normal paths must continue to produce the average of edge costs.
+  it should "process a non-empty path and return finite values" in {
+    val path: PATHRESULT = List((nodeB, edgeAB))
+    val modRecord = Map.empty[NetGraphAlgebraDefs.NetGraphComponent, Double]
+    val initialCosts = (MalAppBudget(10.0), TargetAppScore(5.0))
+
+    val ((newBudget, newScore), _) =
+      CostRewardCalculator(path, modRecord, List())(initialCosts)
+
+    newBudget.toDouble.isNaN shouldBe false
+    newBudget.toDouble.isInfinite shouldBe false
+    newScore.toDouble.isNaN shouldBe false
+    newScore.toDouble.isInfinite shouldBe false
+    logger.info(s"Non-empty path produced finite values: budget=${newBudget.toDouble}, score=${newScore.toDouble}")
+  }
+}


### PR DESCRIPTION
## What this fixes

In [`CostRewardCalculator`](NetModelGenerator/src/main/scala/NetModelAnalyzer/CostRewardCalculator.scala), when the input `PATHRESULT` is empty, the average-weight computation produced `NaN` by dividing by zero. That `NaN` was then fed into `MalAppBudget.reward(avgWeight)` / `MalAppBudget.penalty(avgWeight)`, silently poisoning every subsequent budget/score calculation for the remainder of the simulation.

### Before

```scala
val pathLength = v1.size.toDouble
val avgWeight: Double = v1.map(_._2.asInstanceOf[Action].cost).sum / pathLength
// When v1 is empty, pathLength = 0.0 and avgWeight = 0.0 / 0.0 = NaN
```

### After

```scala
val pathLength = v1.size.toDouble
val avgWeight: Double =
  if pathLength > 0d then v1.map(_._2.asInstanceOf[Action].cost).sum / pathLength
  else 0d
```

## How an empty path reaches this code

`RandomWalker.trimPath` returns an empty list when a walk terminates immediately at a `TerminalNode` (the only element gets dropped by `.tail.reverse`). This is reachable under both the `MaxPathLengthIsReached` and `AllTerminationConditions` policies for short-lived walks on small or sparse generated graphs.

When `Analyzer.computeTotalCostsRewards` iterates walks, each empty walk injected a `NaN` into the running budget. Since `NaN != NaN` and arithmetic with `NaN` propagates, the scoring and ranking of target-app vs doppelganger-app at the end of each experiment became meaningless (all `NaN`) whenever even one empty walk occurred.

## Regression test

Added `CostRewardCalculatorTest.scala` (first dedicated test file for this module) with:

1. **Regression test** — passes an empty `PATHRESULT` and asserts that the returned `MalAppBudget` and `TargetAppScore` are finite. Under the old code this fails because the budget becomes `NaN`.
2. **Sanity test** — passes a non-empty path and asserts finite values, confirming the guard does not over-fire and break the happy path.

## Test Plan

- [ ] Run `sbt test` to verify both `CostRewardCalculatorTest` cases pass
- [ ] Reviewers can confirm the fix by temporarily reverting the guard — the first test will fail with `isNaN = true`