### PR TITLE
Close file resources on failure and fail gracefully on malformed JSON

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -9,7 +9,7 @@ import guru.nidi.graphviz.attribute.{Color, Font, Label, LinkAttr, Rank, Style}
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success, Try, Using}
 import guru.nidi.graphviz.engine.{EngineResult, Format, Graphviz, GraphvizCmdLineEngine, GraphvizJdkEngine, GraphvizServerEngine}
 import guru.nidi.graphviz.model.Factory.{graph, linkAttrs, node, to}
 import guru.nidi.graphviz.model.{Graph, Node}
@@ -36,7 +36,12 @@ trait GraphStore:
     val outputGraphRepresentation = config.getConfig("NGSimulator").getConfig("OutputGraphRepresentation").getString("contentType")
     val graphDirectionality = config.getConfig("NGSimulator").getConfig("Graph").getString("directionality")
     if (outputGraphRepresentation == "json") then
-        Try {
+        // JSON export. Previously the FileWriter was constructed inside a Try
+        // block and closed only on the happy path, so any exception thrown
+        // by write() (e.g. disk full, I/O error) would leak the file handle
+        // because close() was never reached. Wrapping in Using guarantees
+        // the handle is released in every code path via try-with-resources.
+        Using(new FileWriter(s"$dir$fileName")) { file =>
           val nodesInGraph: String = sm.nodes().asScala.asJson.noSpaces
           val edgesInGraph: String = sm.edges().asScala.toList.map { edge =>
             val edgeValue = (if (graphDirectionality == "undirected") then
@@ -51,9 +56,7 @@ trait GraphStore:
             }
           }.asJson.noSpaces
 
-          val file = new FileWriter(s"$dir$fileName")
           file.write(nodesInGraph + "\n" + edgesInGraph)
-          file.close()
         }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in json to $dir$fileName"))
           .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in json to $dir$fileName : ", e) }
     else if (outputGraphRepresentation == "yaml") then
@@ -61,7 +64,9 @@ trait GraphStore:
         // to inspect visually than binary .ngs or dense JSON. The format lists every node
         // with its properties followed by every edge with its action attributes. This uses
         // the same directionality-aware edge value retrieval as the JSON and binary formats.
-        Try {
+        // FileWriter is wrapped in Using so the file handle is released even if write()
+        // throws mid-stream (same leak that the JSON branch suffered from previously).
+        Using(new FileWriter(s"$dir$fileName")) { file =>
           val sb = new StringBuilder
           sb.append("# NetGameSim graph exported in YAML format\n")
           sb.append(s"directionality: $graphDirectionality\n")
@@ -98,9 +103,7 @@ trait GraphStore:
                 NetGraph.logger.warn("Encountered edge without a value during YAML export, skipping")
             }
           }
-          val file = new FileWriter(s"$dir$fileName")
           file.write(sb.toString)
-          file.close()
         }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph in yaml to $dir$fileName"))
           .recover { case e => NetGraph.logger.error(s"Failed to persist the graph in yaml to $dir$fileName : ", e) }
     else {
@@ -115,11 +118,21 @@ trait GraphStore:
           sm.edgeValue(edge.source(), edge.target())
           ).get
       }.asInstanceOf[List[NetGraphComponent]]
-      Try(new FileOutputStream(s"$dir$fileName", false)).map(fos => new ObjectOutputStream(fos)).map { oos =>
+      // Binary .ngs export. The previous .map chain had two leak paths:
+      //   (a) if `new ObjectOutputStream(fos)` threw, the outer
+      //       FileOutputStream was never closed.
+      //   (b) if `writeObject` threw before the explicit `oos.close()` line,
+      //       neither stream was closed.
+      // Nesting two Using blocks guarantees both streams are released in
+      // every exit path. FileOutputStream.close() is idempotent, so the
+      // redundant inner close (via ObjectOutputStream) followed by the
+      // outer Using's close is safe.
+      Using(new FileOutputStream(s"$dir$fileName", false)) { fos =>
+        Using(new ObjectOutputStream(fos)) { oos =>
           oos.writeObject(fullGraphAsList)
           oos.flush()
-          oos.close()
-        }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph to $dir$fileName"))
+        }.get
+      }.map(_ => NetGraph.logger.info(s"Successfully persisted the graph to $dir$fileName"))
         .recover { case e => NetGraph.logger.error(s"Failed to persist the graph to $dir$fileName : ", e) }
     }
 

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
@@ -288,12 +288,36 @@ object NetGraph:
        import io.circe.parser._
        import io.circe.syntax._
 
-       val json = Source.fromFile(s"$dir$fileName").mkString
-       val arr = json.split("\n")
-       val nodes: List[NodeObject] = decode[Set[NodeObject]](arr.head).right.get.toList
-       val edges: List[Action] = decode[Set[Action]](arr.last).right.get.toList
-       logger.info(s"Deserialized ${nodes.length} nodes and ${edges.length} edges from JSON")
-       NetModelAlgebra(nodes, edges)
+       // JSON load path. Two defensive improvements over the original:
+       //  1. Source.fromFile is wrapped in Using so the backing file handle
+       //     is always released. Previously the stream was only consumed
+       //     via .mkString and never closed, leaking one handle per call.
+       //  2. decode[...].right.get is replaced with explicit pattern
+       //     matching on Either. Before, a malformed JSON payload threw
+       //     NoSuchElementException and crashed the caller; now it logs a
+       //     clear error and returns None, which is consistent with the
+       //     Option[NetGraph] contract already used by the binary branch.
+       Using(Source.fromFile(s"$dir$fileName"))(_.mkString).toOption.flatMap { json =>
+         val arr = json.split("\n")
+         if arr.length < 2 then
+           logger.error(s"JSON graph file $dir$fileName is malformed: expected at least two lines (nodes, edges)")
+           None
+         else
+           val nodesEither = decode[Set[NodeObject]](arr.head)
+           val edgesEither = decode[Set[Action]](arr.last)
+           (nodesEither, edgesEither) match
+             case (Right(ns), Right(es)) =>
+               val nodes = ns.toList
+               val edges = es.toList
+               logger.info(s"Deserialized ${nodes.length} nodes and ${edges.length} edges from JSON")
+               NetModelAlgebra(nodes, edges)
+             case (Left(err), _) =>
+               logger.error(s"Failed to decode nodes from $dir$fileName: ${err.getMessage}")
+               None
+             case (_, Left(err)) =>
+               logger.error(s"Failed to decode edges from $dir$fileName: ${err.getMessage}")
+               None
+       }
    end load
 
    @main def runMain_NetGraph(): Unit =


### PR DESCRIPTION
## What this fixes

Two classes of persistence-layer issues that could silently degrade long-running experiments.

---

### 1. File handle leaks in `GraphStore.persist` (all three formats)

The JSON, YAML, and binary `.ngs` branches all constructed the writer inside a `Try` block and called `close()` only on the happy path. If `write()` threw mid-stream (disk full, I/O error, or the existing `throw new IllegalArgumentException(\"Edge without value\")` in the JSON branch), the explicit `close()` was never reached and the file descriptor leaked.

The binary branch had an additional leak: if `new ObjectOutputStream(fos)` threw, the outer `FileOutputStream` was never released.

#### Before (JSON branch — YAML and binary have the same shape)

```scala
Try {
  val nodesInGraph = ...
  val edgesInGraph = ...
  val file = new FileWriter(s\"$dir$fileName\")
  file.write(nodesInGraph + \"\n\" + edgesInGraph)
  file.close()   // only runs on success
}
```

#### After

```scala
Using(new FileWriter(s\"$dir$fileName\")) { file =>
  val nodesInGraph = ...
  val edgesInGraph = ...
  file.write(nodesInGraph + \"\n\" + edgesInGraph)
}  // Using guarantees close() in every exit path
```

The binary branch uses nested `Using` so both streams are released in order:

```scala
Using(new FileOutputStream(s\"$dir$fileName\", false)) { fos =>
  Using(new ObjectOutputStream(fos)) { oos =>
    oos.writeObject(fullGraphAsList)
    oos.flush()
  }.get
}
```

`FileOutputStream.close()` is documented as idempotent, so the inner close (via `ObjectOutputStream`) followed by the outer `Using`'s close is safe.

---

### 2. Unsafe JSON decode and unclosed `Source` in `NetGraph.load`

The JSON load branch had two problems on the same few lines:

#### Before

```scala
val json = Source.fromFile(s\"$dir$fileName\").mkString
val arr = json.split(\"\n\")
val nodes: List[NodeObject] = decode[Set[NodeObject]](arr.head).right.get.toList
val edges: List[Action] = decode[Set[Action]](arr.last).right.get.toList
```

- `Source.fromFile(...).mkString` — the underlying file handle was never closed, leaking one handle per load.
- `.right.get` — throws `NoSuchElementException` and crashes the caller on any malformed payload.

#### After

```scala
Using(Source.fromFile(s\"$dir$fileName\"))(_.mkString).toOption.flatMap { json =>
  val arr = json.split(\"\n\")
  if arr.length < 2 then
    logger.error(s\"... malformed: expected at least two lines (nodes, edges)\")
    None
  else
    (decode[Set[NodeObject]](arr.head), decode[Set[Action]](arr.last)) match
      case (Right(ns), Right(es)) =>
        logger.info(s\"Deserialized \${ns.size} nodes and \${es.size} edges from JSON\")
        NetModelAlgebra(ns.toList, es.toList)
      case (Left(err), _) =>
        logger.error(s\"Failed to decode nodes ...: \${err.getMessage}\")
        None
      case (_, Left(err)) =>
        logger.error(s\"Failed to decode edges ...: \${err.getMessage}\")
        None
}
```

Malformed payloads now log a descriptive error and return `None`, matching the `Option[NetGraph]` contract already used by the binary `.ngs` load branch.

## Test Plan

- [ ] Run `sbt test` to confirm nothing regresses
- [ ] Reviewers can verify leaks are fixed by running `persist` with a full disk / read-only directory — previously the handle would stay open, now it is released
- [ ] Reviewers can verify the decode fix by loading a JSON file with a single malformed line — previously `NoSuchElementException`, now a clean `None` with an error log