### PR TITLE
Fix misleading cycle count log message in Analyzer

### DIFF
--- a/NetModelGenerator/src/main/scala/NetModelAnalyzer/Analyzer.scala
+++ b/NetModelGenerator/src/main/scala/NetModelAnalyzer/Analyzer.scala
@@ -32,7 +32,12 @@ object Analyzer:
     val jg: Graph[NodeObject, Action] = new MutableValueGraphAdapter(gc.sm, createAction(gc.initState,gc.initState), (x: Action) => x.cost).asInstanceOf[Graph[NodeObject, Action]]
     val inspector = new KosarajuStrongConnectivityInspector(jg)
     val components = inspector.stronglyConnectedSets().asScala.toList.filter(_.size > 1)
-    logger.info(s"Detected ${components.map(_.size)} cycles")
+    // Previously: logger.info(s"Detected ${components.map(_.size)} cycles")
+    // That interpolated a List[Int] into the log message, producing output
+    // like "Detected List(5, 3, 2) cycles" instead of a count. We now log
+    // the number of detected strongly-connected components (i.e. cycles)
+    // alongside their individual sizes for diagnostic context.
+    logger.info(s"Detected ${components.size} cycles with sizes ${components.map(_.size).mkString("[", ", ", "]")}")
 
     val newg = g.copy
     newg.sm.removeNode(newg.sm.nodes().asScala.find(_.id == 3).get)


### PR DESCRIPTION
## What this fixes

In [`Analyzer.scala`](NetModelGenerator/src/main/scala/NetModelAnalyzer/Analyzer.scala) the cycle-detection log line interpolates a `List[Int]` into a message that promises a scalar count.

### Before

```scala
val components = inspector.stronglyConnectedSets().asScala.toList.filter(_.size > 1)
logger.info(s\"Detected \${components.map(_.size)} cycles\")
```

For a graph with three strongly-connected components of sizes 5, 3, and 2, this logs:

```
Detected List(5, 3, 2) cycles
```

…instead of `Detected 3 cycles`. The message format suggests a scalar followed by a noun, so readers scanning logs will misread it as \"List of 5 3 2 cycles\" or simply be confused about how many cycles were actually found.

### After

```scala
logger.info(s\"Detected \${components.size} cycles with sizes \${components.map(_.size).mkString(\"[\", \", \", \"]\")}\")
```

Now logs:

```
Detected 3 cycles with sizes [5, 3, 2]
```

The count is up-front, the sizes are kept as diagnostic context, and the formatting uses explicit brackets via `mkString` instead of relying on `List.toString`.

## Test Plan

- [x] Run `sbt test` to confirm nothing regresses (this is a log-only change, no behavior change).
- [ ] Manually run the `runAnalyzer` main to confirm the new log format is correct.