### PR TITLE
Remove duplicate initState in toDotVizFormat node list

### DIFF
--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -128,7 +128,16 @@ trait GraphStore:
   def toDotVizFormat(name: String, dir: String = outputDirectory, fileName: String, outputImageFormat: Format = Format.DOT): Unit =
     val config = ConfigFactory.load()
     val graphDirectionality = config.getConfig("NGSimulator").getConfig("Graph").getString("directionality")
-    val nodes: List[NodeObject] = initState :: sm.nodes().asScala.toList
+    // The init state is always added to the state machine by
+    // NetModelAlgebra.addInitState, so it is already present in sm.nodes().
+    // The previous code prepended it unconditionally which produced a
+    // duplicate entry. It worked only because the subsequent foldLeft keys
+    // the nodes by id, silently collapsing the duplicate. We avoid the
+    // duplicate up-front and keep a defensive fallback for graphs where
+    // initState is not present (e.g. hand-constructed test fixtures).
+    val smNodes: List[NodeObject] = sm.nodes().asScala.toList
+    val nodes: List[NodeObject] =
+      if smNodes.contains(initState) then smNodes else initState :: smNodes
     if nodes.count(_.id == 0) < 1 then
       logger.error("The graph does not contain a start node with id 0")
     else if (graphDirectionality == "directed") then


### PR DESCRIPTION
## What this fixes

In [`GraphStore.toDotVizFormat`](NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala), the working node list is constructed as:

### Before

```scala
val nodes: List[NodeObject] = initState :: sm.nodes().asScala.toList
```

But the init state is **already added to the state machine** during graph construction — see [`NetModelAlgebra.addInitState`](NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetModelAlgebra.scala) which calls `stateMachine.addNode(newInitNode)` and then returns that same `newInitNode` as the graph's `initState`. The prepend in `toDotVizFormat` therefore produces a duplicate entry every time.

### After

```scala
val smNodes: List[NodeObject] = sm.nodes().asScala.toList
val nodes: List[NodeObject] =
  if smNodes.contains(initState) then smNodes else initState :: smNodes
```

If `initState` is already present (the normal production case), we use `sm.nodes()` as-is. The defensive fallback keeps the old prepend behavior for hand-constructed test fixtures that build a `NetGraph` without first adding `initState` to the state machine.

## Why it worked by accident

The subsequent `foldLeft` builds a `Map[Int, Node]` keyed by `nd.id`, so the duplicate entry for the init node silently collapsed into a single map value. The rendered DOT output was therefore correct. But the duplicate still made the fold iterate one more time than necessary and — more importantly — indicates an incorrect invariant assumption in the code: \"`sm.nodes()` does not include `initState`\", which is not true.

## Test Plan

- [ ] Run `sbt test` to confirm no regressions (the rendered DOT output was already correct due to map deduplication, so behavior is unchanged).
- [ ] Manually run `Main` to generate a graph and visually inspect the resulting `.dot` file — still contains the init node exactly once.