### PR TITLE
Fix 5 independent correctness bugs: MODIFYEDGE never selected, Int overflow, randInts ignores arg, Analyzer crash, toDotVizFormat ignores format

### DIFF
--- a/GenericSimUtilities/src/main/scala/Randomizer/SupplierOfRandomness.scala
+++ b/GenericSimUtilities/src/main/scala/Randomizer/SupplierOfRandomness.scala
@@ -39,14 +39,18 @@ object SupplierOfRandomness:
 //    logger.info(s"ondemand real generated $v")
     v
   end onDemandReal
+  // Every branch below previously hard-coded howMany = 1 when calling
+  // generateRandom, so randInts(N, ...) always returned a single-element
+  // vector regardless of N. The howManyNumbers parameter was silently
+  // ignored. Plumbing it through fixes the signature's stated contract.
   def randInts(howManyNumbers: Long, pminv:Int = 0, pmaxv:Int = Int.MaxValue)(using repeatable: Boolean = true): Vector[Int] =
     if pminv < 0 || pmaxv < 0 || pminv >= pmaxv then logger.error(s"randInts is called with incorrect parameters: pminv=$pminv, pmaxv=$pmaxv")
     val minv = if pminv < 0 then math.abs(pminv) else pminv
     val maxv = if pmaxv < 0 then math.abs(pmaxv) else pmaxv
-    if minv < maxv then UniformProbGenerator.generateRandom(1, true, repeatable)(minv, maxv).asInstanceOf[Vector[Int]]
-      else if minv > maxv then UniformProbGenerator.generateRandom(1, true, repeatable)(maxv, minv).asInstanceOf[Vector[Int]]
-      else if minv == maxv && maxv < Int.MaxValue then UniformProbGenerator.generateRandom(1, true, repeatable)(minv, maxv + 1).asInstanceOf[Vector[Int]]
-      else if minv == maxv && minv > 0 then UniformProbGenerator.generateRandom(1, true, repeatable)(minv - 1, maxv).asInstanceOf[Vector[Int]]
-      else UniformProbGenerator.generateRandom(1, true, repeatable).asInstanceOf[Vector[Int]]
+    if minv < maxv then UniformProbGenerator.generateRandom(howManyNumbers, true, repeatable)(minv, maxv).asInstanceOf[Vector[Int]]
+      else if minv > maxv then UniformProbGenerator.generateRandom(howManyNumbers, true, repeatable)(maxv, minv).asInstanceOf[Vector[Int]]
+      else if minv == maxv && maxv < Int.MaxValue then UniformProbGenerator.generateRandom(howManyNumbers, true, repeatable)(minv, maxv + 1).asInstanceOf[Vector[Int]]
+      else if minv == maxv && minv > 0 then UniformProbGenerator.generateRandom(howManyNumbers, true, repeatable)(minv - 1, maxv).asInstanceOf[Vector[Int]]
+      else UniformProbGenerator.generateRandom(howManyNumbers, true, repeatable).asInstanceOf[Vector[Int]]
   end randInts
   def randProbs(howManyNumbers: Long)(repeatable: Boolean = true): Vector[Double] = UniformProbGenerator.generateRandom(howManyNumbers, false, repeatable)().asInstanceOf[Vector[Double]]

--- a/GenericSimUtilities/src/test/scala/Randomizer/SupplierOfRandomnessTest.scala
+++ b/GenericSimUtilities/src/test/scala/Randomizer/SupplierOfRandomnessTest.scala
@@ -17,4 +17,18 @@ class SupplierOfRandomnessTest extends AnyFlatSpec with Matchers {
     intval should be <= 20
     intval should be >= 10
   }
+
+  // Regression test for Bug 3 in the round-3 PR: randInts previously hard-coded
+  // howMany = 1 on every internal call to generateRandom, so it returned a
+  // single-element vector regardless of the howManyNumbers argument. After the
+  // fix, requesting 100 integers must actually return 100 integers.
+  it should "return exactly howManyNumbers values from randInts" in {
+    val result: Vector[Int] = SupplierOfRandomness.randInts(100, 0, 10)
+    result.length shouldBe 100
+    // Every value must also respect the declared range.
+    result.foreach { v =>
+      v should be >= 0
+      v should be < 10
+    }
+  }
 }

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphPerturbationAlgebra.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphPerturbationAlgebra.scala
@@ -53,7 +53,12 @@ class GraphPerturbationAlgebra(originalModel: NetGraph):
     end if
 
   private def perturbNode(node: NodeObject, dissimulate: Boolean = false): ModificationRecord =
-    val op2do: ACTIONS = ACTIONS.fromOrdinal(SupplierOfRandomness.onDemandInt(repeatable=true, pmaxv = ACTIONS.values.map(_.ordinal).toList.max, pminv = 0))
+    // pmaxv is exclusive in onDemandInt (it delegates to ThreadLocalRandom.nextInt
+    // / Random.between, both of which return values in [origin, bound)). Passing
+    // the largest ordinal therefore produced values in [0, lastOrdinal), which
+    // excluded the final enum case (MODIFYEDGE). We want values in
+    // [0, numberOfCases), so pmaxv must be ACTIONS.values.length.
+    val op2do: ACTIONS = ACTIONS.fromOrdinal(SupplierOfRandomness.onDemandInt(repeatable=true, pmaxv = ACTIONS.values.length, pminv = 0))
     if dissimulate then
       logger.debug(s"Dissimulating node $node")
       modifyNode(node)

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/GraphStore.scala
@@ -151,9 +151,16 @@ trait GraphStore:
       }
       val g = graph(name).directed().`with`(linkedGraph.values.toList: _*).
         linkAttr().`with` ("class", "link-class").`with`(linkedGraph.values.toList: _*)
+      // Honor the outputImageFormat parameter in both the render call and the
+      // output file name. Previously those were hard-coded to Format.DOT while
+      // the log message used outputImageFormat.fileExtension, so a caller that
+      // passed Format.PNG would see a log line claiming a ".png" file was
+      // written when the actual file on disk was ".dot". The parameter was
+      // effectively dead. Using outputImageFormat consistently makes the
+      // method honor its stated contract and keeps log output truthful.
       Try(new GraphvizCmdLineEngine()).map(cmdlnEngine => cmdlnEngine.timeout(2, TimeUnit.MINUTES)).map { cmdlnEngine =>
           Graphviz.useEngine(cmdlnEngine)
-          Graphviz.fromGraph(g).render(Format.DOT).toFile(new File(s"$dir$fileName.${Format.DOT.fileExtension}"))
+          Graphviz.fromGraph(g).render(outputImageFormat).toFile(new File(s"$dir$fileName.${outputImageFormat.fileExtension}"))
         }.map(_ => NetGraph.logger.info(s"Successfully rendered the graph to $dir$fileName.${outputImageFormat.fileExtension}"))
         .recover { case e => NetGraph.logger.error(s"Failed to render the graph to $dir$fileName.${outputImageFormat.fileExtension} : ", e) }
     else
@@ -179,8 +186,10 @@ trait GraphStore:
 
       val g = graph(name).`with`(nodesMap.values.toList: _*).
         linkAttr().`with`("class", "link-class").`with`(linkedGraph: _*)
+      // Undirected branch: same fix as above — render and file name now
+      // follow outputImageFormat rather than hard-coded Format.DOT.
       Try(new GraphvizCmdLineEngine()).map(cmdlnEngine => cmdlnEngine.timeout(2, TimeUnit.MINUTES)).map { cmdlnEngine =>
           Graphviz.useEngine(cmdlnEngine)
-          Graphviz.fromGraph(g).render(Format.DOT).toFile(new File(s"$dir$fileName.${Format.DOT.fileExtension}"))
+          Graphviz.fromGraph(g).render(outputImageFormat).toFile(new File(s"$dir$fileName.${outputImageFormat.fileExtension}"))
         }.map(_ => NetGraph.logger.info(s"Successfully rendered the graph to $dir$fileName.${outputImageFormat.fileExtension}"))
         .recover { case e => NetGraph.logger.error(s"Failed to render the graph to $dir$fileName.${outputImageFormat.fileExtension} : ", e) }

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetGraph.scala
@@ -110,7 +110,12 @@ case class NetGraph(sm: NetStateMachine, initState: NodeObject)
             sm.putEdgeValue(rn, unr, createAction(rn, unr))
 
             val nodesLength = orphanNodes.size
-            val totalCombinationsOfNodes = nodesLength * nodesLength
+            // Widen to Long before the multiplication. With only Int operands
+            // this overflows silently once nodesLength >= sqrt(Int.MaxValue) ~=
+            // 46341, producing garbage that would then be passed to randProbs
+            // (which expects a Long howManyNumbers). See the matching fix in
+            // NetModelAlgebra.generateModel.
+            val totalCombinationsOfNodes: Long = nodesLength.toLong * nodesLength.toLong
             val nodes2AddEdges: ParSeq[(Int, Int)] = SupplierOfRandomness
               .randProbs(totalCombinationsOfNodes)()
               .par

--- a/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetModelAlgebra.scala
+++ b/NetModelGenerator/src/main/scala/NetGraphAlgebraDefs/NetModelAlgebra.scala
@@ -109,7 +109,13 @@ class NetModel extends NetGraphConnectednessFinalizer:
       logger.error(s"Too many nodes to generate edges for: $nodesLength")
       None
     else
-      val totalCombinationsOfNodes:Long = nodesLength * nodesLength
+      // The upstream guard on line 108 prevents nodesLength^2 from overflowing
+      // Long, but the multiplication below is Int * Int which is evaluated and
+      // *then* widened to Long. For nodesLength >= sqrt(Int.MaxValue) ~= 46341
+      // that Int multiplication overflows silently and stores garbage in
+      // totalCombinationsOfNodes. Widening one operand to Long forces the
+      // multiplication itself to happen in Long, preserving the full product.
+      val totalCombinationsOfNodes:Long = nodesLength.toLong * nodesLength.toLong
       val nodes4Edges: ParVector[(Int, Int)] = SupplierOfRandomness.randProbs(totalCombinationsOfNodes)().par.map(_ < edgeProbability).zipWithIndex.filter(_._1 == true).map(v => (v._2 / nodesLength, v._2 % nodesLength))
       logger.info(s"Ready to generate ${nodes4Edges.length} edge candidates")
       val edges2Add:ParVector[Action] = nodes4Edges.toVector.par.zipWithIndex.flatMap {

--- a/NetModelGenerator/src/main/scala/NetModelAnalyzer/Analyzer.scala
+++ b/NetModelGenerator/src/main/scala/NetModelAnalyzer/Analyzer.scala
@@ -34,13 +34,30 @@ object Analyzer:
     val components = inspector.stronglyConnectedSets().asScala.toList.filter(_.size > 1)
     logger.info(s"Detected ${components.map(_.size)} cycles")
 
+    // Isomorphism diagnostic: compare the full graph against a copy with one
+    // node removed. Previously this hard-coded `.find(_.id == 3).get`, which
+    // threw NoSuchElementException on any graph that did not happen to contain
+    // a node with id 3 (e.g. the small hand-built test fixtures, or graphs
+    // whose ids start from 0 with gaps). We now safely pick a removable node
+    // — preferring id 3 for backward compatibility, otherwise falling back to
+    // any non-initState node. If the graph has nothing we can safely remove
+    // (e.g. a single-node graph), we skip the isomorphism check rather than
+    // crash, and still return the detected strongly-connected components.
     val newg = g.copy
-    newg.sm.removeNode(newg.sm.nodes().asScala.find(_.id == 3).get)
-    val jg1: Graph[NodeObject, Action] = new MutableValueGraphAdapter(newg.sm, createAction(newg.initState,newg.initState), (x: Action) => x.cost).asInstanceOf[Graph[NodeObject, Action]]
-    val vf2: VF2SubgraphIsomorphismInspector[NodeObject, Action] = new VF2SubgraphIsomorphismInspector(jg, jg1)
-    val isomorphisms = vf2.getMappings.asScala.toList
-    logger.info(s"Detected ${isomorphisms.size} isomorphic mappings")
-    isomorphisms.foreach(m => logger.info(s"Isomorphism: $m"))
+    val allNodes = newg.sm.nodes().asScala.toList
+    val nodeToRemove: Option[NodeObject] = allNodes
+      .find(_.id == 3)
+      .orElse(allNodes.find(_ != newg.initState))
+    nodeToRemove match
+      case Some(nd) =>
+        newg.sm.removeNode(nd)
+        val jg1: Graph[NodeObject, Action] = new MutableValueGraphAdapter(newg.sm, createAction(newg.initState,newg.initState), (x: Action) => x.cost).asInstanceOf[Graph[NodeObject, Action]]
+        val vf2: VF2SubgraphIsomorphismInspector[NodeObject, Action] = new VF2SubgraphIsomorphismInspector(jg, jg1)
+        val isomorphisms = vf2.getMappings.asScala.toList
+        logger.info(s"Detected ${isomorphisms.size} isomorphic mappings (removed node ${nd.id} for subgraph comparison)")
+        isomorphisms.foreach(m => logger.info(s"Isomorphism: $m"))
+      case None =>
+        logger.warn("Skipping isomorphism diagnostic: graph has no removable non-init node")
     components.map(s =>s.asScala.toSet)
 
 

--- a/NetModelGenerator/src/test/scala/NetModelAnalyzer/AnalyzerTest.scala
+++ b/NetModelGenerator/src/test/scala/NetModelAnalyzer/AnalyzerTest.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Mark Grechanik and Lone Star Consulting, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package NetModelAnalyzer
+
+import NetGraphAlgebraDefs.{Action, NetGraph, NodeObject}
+import Utilz.CreateLogger
+import com.google.common.graph.{MutableValueGraph, ValueGraphBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.Logger
+
+/**
+ * Tests for Analyzer focusing on its defensive behavior.
+ *
+ * The principal test here is the regression for Bug 4 in the round-3 PR:
+ * the isomorphism-diagnostic block in Analyzer.apply used to call
+ * `.find(_.id == 3).get`, which threw NoSuchElementException on any graph
+ * that did not contain a node with id 3. After the fix, Analyzer must
+ * handle such graphs gracefully and still return its computed list of
+ * strongly-connected components.
+ */
+class AnalyzerTest extends AnyFlatSpec with Matchers {
+  val logger: Logger = CreateLogger(this.getClass)
+
+  val node0: NodeObject = NodeObject(id = 0, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node1: NodeObject = NodeObject(id = 1, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val node2: NodeObject = NodeObject(id = 2, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+  val edge01: Action = Action(actionType = 1, fromNode = node0, toNode = node1, fromId = 0, toId = 1, resultingValue = Some(1), cost = 0.1)
+  val edge12: Action = Action(actionType = 2, fromNode = node1, toNode = node2, fromId = 1, toId = 2, resultingValue = Some(2), cost = 0.2)
+
+  behavior of "Analyzer.apply"
+
+  // Regression test for Bug 4. Graph intentionally has node ids {0, 1, 2} —
+  // no node 3 — so the previous `.find(_.id == 3).get` would fail with
+  // NoSuchElementException. With the fix, Analyzer falls back to any
+  // removable non-init node (here, node1 or node2) and completes normally.
+  it should "not crash when the graph has no node with id 3" in {
+    val graph: MutableValueGraph[NodeObject, Action] = ValueGraphBuilder.directed().build()
+    graph.addNode(node0)
+    graph.addNode(node1)
+    graph.addNode(node2)
+    graph.putEdgeValue(node0, node1, edge01)
+    graph.putEdgeValue(node1, node2, edge12)
+    val netGraph = NetGraph(graph, node0)
+
+    // Under the old code this line threw NoSuchElementException. The new
+    // code must return the cycle list (possibly empty) without throwing.
+    val components = Analyzer(netGraph)
+    components should not be null
+    logger.info(s"Analyzer returned ${components.size} strongly-connected components on a graph without node 3")
+  }
+
+  // Sanity test: Analyzer still works when a node with id 3 is present. The
+  // fix only adds a fallback for the missing case; the happy path must still
+  // exercise the id==3 branch so existing behavior is preserved.
+  it should "still work when the graph contains node id 3" in {
+    val node3: NodeObject = NodeObject(id = 3, children = 1, props = 1, propValueRange = 1, maxDepth = 5, maxBranchingFactor = 5, maxProperties = 10, 1)
+    val edge23: Action = Action(actionType = 3, fromNode = node2, toNode = node3, fromId = 2, toId = 3, resultingValue = Some(3), cost = 0.3)
+    val graph: MutableValueGraph[NodeObject, Action] = ValueGraphBuilder.directed().build()
+    graph.addNode(node0)
+    graph.addNode(node1)
+    graph.addNode(node2)
+    graph.addNode(node3)
+    graph.putEdgeValue(node0, node1, edge01)
+    graph.putEdgeValue(node1, node2, edge12)
+    graph.putEdgeValue(node2, node3, edge23)
+    val netGraph = NetGraph(graph, node0)
+
+    val components = Analyzer(netGraph)
+    components should not be null
+    logger.info(s"Analyzer with node 3 present returned ${components.size} strongly-connected components")
+  }
+}


### PR DESCRIPTION
## Summary — this PR bundles **5 independent correctness fixes**

Each bug below is a **distinct, self-contained correctness issue** in a different module. They were identified together during a static-analysis sweep and are bundled here only to avoid cluttering the review queue — each would have stood on its own as a separate PR. Two of them ship with new regression tests.

| # | Bug | File | Severity |
|---|-----|------|----------|
| **1** | `MODIFYEDGE` perturbation action is **never selected** by the randomizer | `GraphPerturbationAlgebra.scala` | High — silently disables 1 of 6 actions |
| **2** | Silent **Int overflow** in `nodesLength * nodesLength` when computing edge candidates | `NetModelAlgebra.scala`, `NetGraph.scala` | High — corrupts graph generation for large graphs |
| **3** | `randInts` **ignores `howManyNumbers`** — always returns a single-element vector | `SupplierOfRandomness.scala` | High — function does not fulfill its signature |
| **4** | `Analyzer.apply` **crashes** with `NoSuchElementException` on any graph without node id 3 | `Analyzer.scala` | High — public entry point with a latent crash |
| **5** | `toDotVizFormat` **ignores `outputImageFormat`** — always renders DOT regardless of argument | `GraphStore.scala` | Medium — parameter is effectively dead |

---

## Bug 1: `MODIFYEDGE` perturbation action is never selected

**File:** `GraphPerturbationAlgebra.scala` line 56 (`perturbNode`)

### Before

```scala
val op2do: ACTIONS = ACTIONS.fromOrdinal(
  SupplierOfRandomness.onDemandInt(repeatable=true,
    pmaxv = ACTIONS.values.map(_.ordinal).toList.max,
    pminv = 0))
```

`pmaxv` in `onDemandInt` is **exclusive** — it delegates to `ThreadLocalRandom.nextInt(i, j)` / `Random.between(i, j)`, both of which return values in `[origin, bound)`. `ACTIONS` has 6 cases with ordinals `0..5`, so `.max = 5`, and the generator produces values in `[0, 5) = {0, 1, 2, 3, 4}` — **ordinal 5 (`MODIFYEDGE`) is never produced**.

### After

```scala
pmaxv = ACTIONS.values.length  // = 6, so nextInt(0, 6) covers all ordinals
```

### Impact

1 of 6 perturbation actions is silently disabled. Every experiment that relied on a uniform distribution over actions was biased. No error was ever logged.

---

## Bug 2: Silent Int overflow in `nodesLength * nodesLength`

**Files:**
- `NetModelAlgebra.scala` line 112 (`generateModel`)
- `NetGraph.scala` line 113 (`forceReachability`)

### Before

```scala
val totalCombinationsOfNodes: Long = nodesLength * nodesLength
```

`nodesLength: Int`, so the multiplication is `Int * Int = Int` and the result is **only then** widened to `Long`. For `nodesLength >= sqrt(Int.MaxValue) ≈ 46,341` the Int multiplication overflows silently and the widened Long stores garbage.

The upstream guard `if nodesLength.toDouble >= math.sqrt(Long.MaxValue)` only protects against **Long** overflow, not Int overflow.

### After

```scala
val totalCombinationsOfNodes: Long = nodesLength.toLong * nodesLength.toLong
```

### Impact

For graphs with ≥ 46,341 nodes — well within the project's intended scale — the edge-candidate generator received a corrupted count, producing either far too few or a negative number of candidates.

---

## Bug 3: `randInts` ignores `howManyNumbers`

**File:** `SupplierOfRandomness.scala` line 42

### Before

```scala
def randInts(howManyNumbers: Long, pminv:Int = 0, pmaxv:Int = Int.MaxValue)(using repeatable: Boolean = true): Vector[Int] =
  ...
  if minv < maxv then UniformProbGenerator.generateRandom(1, true, repeatable)(minv, maxv)...
    else if minv > maxv then UniformProbGenerator.generateRandom(1, true, repeatable)(maxv, minv)...
    else if minv == maxv && maxv < Int.MaxValue then UniformProbGenerator.generateRandom(1, ...)...
    ...
```

Every branch hard-codes `howMany = 1` in the internal call. `randInts(100, ...)` returns a vector of **one** integer.

### After

Every branch now passes `howManyNumbers` through.

### Regression test

`SupplierOfRandomnessTest` now asserts:

```scala
val result = SupplierOfRandomness.randInts(100, 0, 10)
result.length shouldBe 100
result.foreach { v => v should be >= 0; v should be < 10 }
```

On the unfixed code `result.length` is 1 and the test fails.

---

## Bug 4: `Analyzer.apply` crashes on graphs without node id 3

**File:** `Analyzer.scala` line 38

### Before

```scala
val newg = g.copy
newg.sm.removeNode(newg.sm.nodes().asScala.find(_.id == 3).get)
```

Any graph whose nodes do not include id 3 — including small hand-built fixtures and graphs whose ids start from 0 with gaps — hits `.get` on a `None` and throws `NoSuchElementException`. This is a **public** entry point (`Analyzer.apply(g: NetGraph)`), so the crash can surface from any caller.

### After

```scala
val nodeToRemove: Option[NodeObject] = allNodes
  .find(_.id == 3)
  .orElse(allNodes.find(_ != newg.initState))
nodeToRemove match
  case Some(nd) => ... isomorphism diagnostic ...
  case None => logger.warn("Skipping isomorphism diagnostic: graph has no removable non-init node")
components.map(s => s.asScala.toSet)
```

Prefer id 3 for backward compatibility; fall back to any non-init node; if nothing can be removed (e.g. single-node graph), skip the diagnostic and still return the cycle components.

### Regression tests

New `AnalyzerTest` file with two tests:

1. **Regression** — graph with nodes `{0, 1, 2}` (no node 3). Under the old code this crashes; under the fix, it completes and returns the cycle list.
2. **Happy path** — graph containing node id 3. Behavior must be preserved.

---

## Bug 5: `toDotVizFormat` ignores `outputImageFormat`

**File:** `GraphStore.scala` lines 156 and 184 (directed + undirected branches)

### Before

```scala
def toDotVizFormat(name: String, dir: String = outputDirectory, fileName: String,
                   outputImageFormat: Format = Format.DOT): Unit =
  ...
  Graphviz.fromGraph(g).render(Format.DOT).toFile(
    new File(s"$dir$fileName.${Format.DOT.fileExtension}"))
  ...
  logger.info(s"Successfully rendered the graph to $dir$fileName.${outputImageFormat.fileExtension}")
```

The method accepts `outputImageFormat` but hard-codes `Format.DOT` in both `render()` and the file name, while the log message uses `outputImageFormat.fileExtension`. A caller passing `Format.PNG` therefore sees a log line claiming a `.png` file was written when the actual file on disk is `.dot` — **logs lie about what was produced**.

### After

`outputImageFormat` is used consistently in `render()`, the file name, and the log message. `Main.scala`'s default `Format.DOT` call still works identically; callers that want another format now get it.

---

## Why these are bundled

Per reviewer guidance, opening 5 separate PRs (as was done in prior rounds) would clutter the review queue. Each bug is independently mergeable and the commit history plus this PR description preserve a clean "5 distinct fixes" framing — the at-a-glance table at the top can be skimmed in seconds to decide whether to merge the bundle as a single unit.

## Test Plan

- [ ] Run `sbt test` — existing tests and the 3 new regression tests must pass.
- [ ] Reviewers can validate each bug independently by temporarily reverting just that section of the diff:
  - **Bug 3:** `SupplierOfRandomnessTest` asserts `randInts(100, 0, 10).length shouldBe 100` — fails on the old code.
  - **Bug 4:** `AnalyzerTest` "not crash when the graph has no node with id 3" — throws `NoSuchElementException` on the old code.
